### PR TITLE
fix: standardize on node user in containers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
     "image": "ghcr.io/jhatler/janus-devcontainer:v0.0.0", /* x-release-please-version */
-    "remoteUser": "vscode",
-    "containerUser": "vscode",
+    "remoteUser": "node",
+    "containerUser": "node",
     "postCreateCommand": "docker pull ghcr.io/super-linter/super-linter:v6.5.1"
 }

--- a/devcontainers/janus/.devcontainer/devcontainer.json
+++ b/devcontainers/janus/.devcontainer/devcontainer.json
@@ -57,8 +57,8 @@
         "./local-features/devcontainers",
         "./local-features/shfmt"
     ],
-    "remoteUser": "vscode",
-    "containerUser": "vscode",
+    "remoteUser": "node",
+    "containerUser": "node",
     "postCreateCommand": "/bin/bash -c 'liquidprompt_activate'",
     "customizations": {
         "vscode": {

--- a/devcontainers/janus/.devcontainer/local-features/devcontainers/install.sh
+++ b/devcontainers/janus/.devcontainer/local-features/devcontainers/install.sh
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-USERNAME=${USERNAME:-"vscode"}
+USERNAME=${USERNAME:-"node"}
 
 set -eux
 

--- a/devcontainers/janus/.devcontainer/local-features/liquidprompt/install.sh
+++ b/devcontainers/janus/.devcontainer/local-features/liquidprompt/install.sh
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-USERNAME=${USERNAME:-"vscode"}
+USERNAME=${USERNAME:-"node"}
 
 set -eux
 

--- a/devcontainers/janus/.devcontainer/local-features/release-please/install.sh
+++ b/devcontainers/janus/.devcontainer/local-features/release-please/install.sh
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-USERNAME=${USERNAME:-"codespace"}
+USERNAME=${USERNAME:-"node"}
 
 set -eux
 

--- a/devcontainers/janus/.devcontainer/local-features/shfmt/install.sh
+++ b/devcontainers/janus/.devcontainer/local-features/shfmt/install.sh
@@ -5,7 +5,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-USERNAME=${USERNAME:-"vscode"}
+USERNAME=${USERNAME:-"node"}
 
 set -eux
 


### PR DESCRIPTION
node, vscode, and codespaces were all present which made it difficult to know which would actually be used. All values are node now.

Fixes: #14
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>