### PR TITLE
fix: correct dependabot paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
-  - package-ecosystem: "devcontainers"
-    directory: "/"
+  - package-ecosystem: "docker"
+    directory: "/containers/janus/"
     schedule:
       interval: "weekly"
   - package-ecosystem: "devcontainers"
@@ -13,6 +13,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"
-    directory: "/"
+    directory: "/lib/pyjanus/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This updates the dependabot paths to match the directory structure.

Fixes: #12
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>