### PR TITLE
fix: correct pyJanus name in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,18 +15,59 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "changelog-sections": [
-        { "type": "feat", "section": "Features" },
-        { "type": "feature", "section": "Features" },
-        { "type": "fix", "section": "Bug Fixes" },
-        { "type": "perf", "section": "Performance Improvements" },
-        { "type": "revert", "section": "Reverts" },
-        { "type": "docs", "section": "Documentation" },
-        { "type": "style", "section": "Styles" },
-        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
-        { "type": "refactor", "section": "Code Refactoring", "hidden": false },
-        { "type": "test", "section": "Tests", "hidden": true },
-        { "type": "build", "section": "Build System", "hidden": true },
-        { "type": "ci", "section": "Continuous Integration", "hidden": true }
+        {
+            "type": "feat",
+            "section": "Features"
+        },
+        {
+            "type": "feature",
+            "section": "Features"
+        },
+        {
+            "type": "fix",
+            "section": "Bug Fixes"
+        },
+        {
+            "type": "perf",
+            "section": "Performance Improvements"
+        },
+        {
+            "type": "revert",
+            "section": "Reverts"
+        },
+        {
+            "type": "docs",
+            "section": "Documentation"
+        },
+        {
+            "type": "style",
+            "section": "Styles"
+        },
+        {
+            "type": "chore",
+            "section": "Miscellaneous Chores",
+            "hidden": true
+        },
+        {
+            "type": "refactor",
+            "section": "Code Refactoring",
+            "hidden": false
+        },
+        {
+            "type": "test",
+            "section": "Tests",
+            "hidden": true
+        },
+        {
+            "type": "build",
+            "section": "Build System",
+            "hidden": true
+        },
+        {
+            "type": "ci",
+            "section": "Continuous Integration",
+            "hidden": true
+        }
     ],
     "include-component-in-tag": true,
     "include-v-in-tag": true,
@@ -34,7 +75,7 @@
     "packages": {
         ".": {
             "release-type": "node",
-            "package-name": "janus",
+            "package-name": "Janus",
             "component": "janus"
         },
         ".devcontainer": {
@@ -44,6 +85,14 @@
             "extra-files": [
                 "devcontainer.json"
             ]
+        },
+        "packages/janus.js": {
+            "release-type": "node",
+            "package-name": "Janus.js"
+        },
+        "lib/pyjanus": {
+            "release-type": "python",
+            "package-name": "pyJanus"
         },
         "containers/janus": {
             "release-type": "docker",
@@ -57,14 +106,6 @@
             "extra-files": [
                 ".devcontainer/devcontainer.json"
             ]
-        },
-        "packages/janus.js": {
-            "release-type": "node",
-            "package-name": "janusjs"
-        },
-        "lib/pyjanus": {
-            "release-type": "python",
-            "package-name": "janusjs"
         }
     }
 }


### PR DESCRIPTION
This commit corrects the name of the pyJanus package (was a duplicate of janusjs) and updates the rest of the package names for better readability.

Fixes: #20
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>