### PR TITLE
chore: set initial version to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -71,7 +71,7 @@
     ],
     "include-component-in-tag": true,
     "include-v-in-tag": true,
-    "initial-version": "0.0.1",
+    "initial-version": "0.1.0",
     "packages": {
         ".": {
             "release-type": "node",


### PR DESCRIPTION
It was improperly set to 0.0.1 before this commit.

Fixes: #25
Jaremy Hatler <hatler.jaremy@gmail.com>