### PR TITLE
fix: force generic updater in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -83,7 +83,10 @@
             "package-name": "devcontainer",
             "component": "devcontainer",
             "extra-files": [
-                "devcontainer.json"
+                {
+                    "type": "generic",
+                    "path": "devcontainer.json"
+                }
             ]
         },
         "packages/janus.js": {
@@ -104,7 +107,10 @@
             "package-name": "devcontainer-janus",
             "component": "devcontainer-janus",
             "extra-files": [
-                ".devcontainer/devcontainer.json"
+                {
+                    "type": "generic",
+                    "path": ".devcontainer/devcontainer.json"
+                }
             ]
         }
     }


### PR DESCRIPTION
This forces the use of the generic updater in release-please for the devcontainer JSON files. This is needed because otherwise release-please will use the JSON updater, which doesn't support JSONC (comments).

Fixes: #27
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>