### PR TITLE
fix: use image digest instead of id to attest

### DIFF
--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -86,11 +86,13 @@ runs:
         push: false
 
     - name: Load container
+      id: load
       if: ${{ inputs.push == 'true' }}
       shell: bash
       run: |
         docker load -i ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
         rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
+        echo "digest=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ steps.build.outputs.imageid }} | cut -f2 -d@)" >> "$GITHUB_OUTPUT"
 
     - name: Tag container
       if: ${{ inputs.push == 'true' }}
@@ -132,6 +134,6 @@ runs:
       if: ${{ inputs.push == 'true' }}
       with:
         subject-name: ${{ inputs.repository }}
-        subject-digest: ${{ steps.build.outputs.digest }}
+        subject-digest: ${{ steps.load.outputs.digest }}
         push-to-registry: true
     # jscpd:ignore-end

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -104,7 +104,7 @@ runs:
         docker load -i ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
         rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
         rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.stdout
-        echo "digest=$(docker inspect -f '{{ .Id }}' ${{ steps.build.outputs.image_name }})" >> "$GITHUB_OUTPUT"
+        echo "digest=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ steps.build.outputs.image_name }} | cut -f2 -d@)" >> "$GITHUB_OUTPUT"
 
     - name: Tag devcontainer
       if: ${{ inputs.push == 'true' }}


### PR DESCRIPTION
This updates the (dev)container actions to use the image digest instead of the image id when attesting the images. This should prevent the build failures seen in the v0.1.0 releases.

Fixes: #29
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>