### PR TITLE
fix: perform attest before cleanup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus-devcontainer:v0.1.1", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus-devcontainer:v0.0.0", /* x-release-please-version */
     "remoteUser": "node",
     "containerUser": "node",
     "postCreateCommand": "docker pull ghcr.io/super-linter/super-linter:v6.5.1"

--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -92,6 +92,7 @@ runs:
       run: |
         docker load -i ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
         rm -f ${{ github.workspace }}/${{ steps.uuid.outputs.uuid }}.tar
+        docker inspect -f '{{index .RepoDigests 0}}' ${{ steps.build.outputs.imageid }}
         echo "digest=$(docker inspect -f '{{index .RepoDigests 0}}' ${{ steps.build.outputs.imageid }} | cut -f2 -d@)" >> "$GITHUB_OUTPUT"
 
     - name: Tag container
@@ -114,19 +115,6 @@ runs:
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}
 
-    - name: Cleanup container build
-      if: ${{ inputs.cleanup == 'true' }}
-      shell: bash
-      run: |
-        docker image rm -f ${{ steps.build.outputs.imageid }} \
-          ${{ inputs.repository }}:latest \
-          ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }} \
-          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }} \
-          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }} \
-          ${{ inputs.repository }}:v${{ inputs.semver_major }}
-
-        docker builder prune --all --force --verbose
-
     # jscpd:ignore-start
     - name: Attest
       uses: actions/attest-build-provenance@v1
@@ -137,3 +125,15 @@ runs:
         subject-digest: ${{ steps.load.outputs.digest }}
         push-to-registry: true
     # jscpd:ignore-end
+
+    - name: Cleanup container build
+      if: ${{ inputs.cleanup == 'true' }}
+      shell: bash
+      run: |
+        docker image rm -f ${{ steps.build.outputs.imageid }} \
+          ${{ inputs.repository }}:latest \
+          ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }} \
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}
+        docker builder prune --all --force --verbose

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -126,6 +126,17 @@ runs:
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}
 
+    # jscpd:ignore-start
+    - name: Attest
+      uses: actions/attest-build-provenance@v1
+      id: attest
+      if: ${{ inputs.push == 'true' }}
+      with:
+        subject-name: ${{ inputs.repository }}
+        subject-digest: ${{ steps.load.outputs.digest }}
+        push-to-registry: true
+    # jscpd:ignore-end
+
     - name: Cleanup devcontainer build
       if: ${{ inputs.cleanup == 'true' }}
       shell: bash
@@ -138,14 +149,3 @@ runs:
           ${{ inputs.repository }}:v${{ inputs.semver_major }}
 
         docker builder prune --all --force --verbose
-
-    # jscpd:ignore-start
-    - name: Attest
-      uses: actions/attest-build-provenance@v1
-      id: attest
-      if: ${{ inputs.push == 'true' }}
-      with:
-        subject-name: ${{ inputs.repository }}
-        subject-digest: ${{ steps.load.outputs.digest }}
-        push-to-registry: true
-    # jscpd:ignore-end

--- a/containers/janus/Dockerfile
+++ b/containers/janus/Dockerfile
@@ -1,5 +1,6 @@
 #checkov:skip=CKV_DOCKER_3:Handled by devcontainer
 #checkov:skip=CKV_DOCKER_2:Not applicable
+
 # Build stage
 FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm as build
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-c"]
@@ -8,23 +9,23 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # hadolint ignore=DL3003
 RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-        build-essential=12.9 \
-        wget=1.21.3-1+b2 \
-        gnupg=2.2.40-1.1 \
-        bash-completion=1:2.11-6 \
- && apt-get autoremove --purge -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && find /var/cache/apt -type f -print0 | xargs -0 rm -f
+       && apt-get install -y --no-install-recommends \
+       build-essential=12.9 \
+       wget=1.21.3-1+b2 \
+       gnupg=2.2.40-1.1 \
+       bash-completion=1:2.11-6 \
+       && apt-get autoremove --purge -y \
+       && apt-get clean \
+       && rm -rf /var/lib/apt/lists/* \
+       && find /var/cache/apt -type f -print0 | xargs -0 rm -f
 
 # Testing stage - verify binaries work and have the right permissions
 FROM build as testing
 RUN wget --version \
- && gpg2 --version \
- && node --version \
- && npm --version \
- && tsc --version
+       && gpg2 --version \
+       && node --version \
+       && npm --version \
+       && tsc --version
 
 # Create testing timestamp
 RUN date -u +'%Y-%m-%dT%H:%M:%SZ' > /.build-date

--- a/devcontainers/janus/.devcontainer/devcontainer.json
+++ b/devcontainers/janus/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus:v0.1.1", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus:v0.0.0", /* x-release-please-version */
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"


### PR DESCRIPTION
The cleanup step was being performed before the attest step, which may have been causing the container digest to not be passed to the attest step. This change moves the cleanup step to after the attest step. It also updates the dev/container versions or whitespace to trigger a build.

Fixes: #34