### PR TITLE
fix: correct CHANGELOG headers

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+# Janus Codespace Changelog
+<!--- @generated --->
+
 
 ## [0.1.3](https://github.com/jhatler/janus/compare/devcontainer-v0.1.2...devcontainer-v0.1.3) (2024-05-27)
 
@@ -32,6 +34,3 @@
 ### Bug Fixes
 
 * Standardize on node user in containers ([b57058d](https://github.com/jhatler/janus/commit/b57058da4fecc47aa6659b56973ac30324c9aeb1)), closes [#14](https://github.com/jhatler/janus/issues/14)
-
-<!--- @generated --->
-## Janus Devcontainer Changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+# Just Another Neural Utility System Changelog
+<!--- @generated --->
+
 
 ## [0.1.3](https://github.com/jhatler/janus/compare/janus-v0.1.2...janus-v0.1.3) (2024-05-27)
 
@@ -45,6 +47,3 @@
 * Correct release type for release-please ([c3cb8fc](https://github.com/jhatler/janus/commit/c3cb8fc128bb581f9c0065e74cac1e242bbdd4e0)), closes [#11](https://github.com/jhatler/janus/issues/11)
 * Force generic updater in release-please ([564771c](https://github.com/jhatler/janus/commit/564771c6fbb1ed9351a8de4bdaf1fec598fdd9c7)), closes [#27](https://github.com/jhatler/janus/issues/27)
 * Standardize on node user in containers ([b57058d](https://github.com/jhatler/janus/commit/b57058da4fecc47aa6659b56973ac30324c9aeb1)), closes [#14](https://github.com/jhatler/janus/issues/14)
-
-<!--- @generated --->
-## Just Another Neural Utility System - Root Changelog

--- a/containers/janus/CHANGELOG.md
+++ b/containers/janus/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+# Janus Container Changelog
+<!--- @generated --->
+
 
 ## [0.1.3](https://github.com/jhatler/janus/compare/container-janus-v0.1.2...container-janus-v0.1.3) (2024-05-27)
 
@@ -27,6 +29,3 @@
 ### Features
 
 * Add devcontainer and other GitHub configs ([#9](https://github.com/jhatler/janus/issues/9)) ([e900bd9](https://github.com/jhatler/janus/commit/e900bd98b4221022b0242448ed9f5ff36546d980)), closes [#8](https://github.com/jhatler/janus/issues/8)
-
-<!--- @generated --->
-## Janus Container Changelog

--- a/devcontainers/janus/CHANGELOG.md
+++ b/devcontainers/janus/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+# Janus devcontainer Changelog
+<!--- @generated --->
+
 
 ## [0.1.3](https://github.com/jhatler/janus/compare/devcontainer-janus-v0.1.2...devcontainer-janus-v0.1.3) (2024-05-27)
 
@@ -33,5 +35,3 @@
 
 * Standardize on node user in containers ([b57058d](https://github.com/jhatler/janus/commit/b57058da4fecc47aa6659b56973ac30324c9aeb1)), closes [#14](https://github.com/jhatler/janus/issues/14)
 
-<!--- @generated --->
-## Janus Devcontainer Changelog

--- a/lib/pyjanus/CHANGELOG.md
+++ b/lib/pyjanus/CHANGELOG.md
@@ -1,4 +1,5 @@
-# Changelog
+# pyJanus Changelog
+<!--- @generated --->
 
 ## 0.1.0 (2024-05-27)
 
@@ -6,6 +7,3 @@
 ### Features
 
 * Add devcontainer and other GitHub configs ([#9](https://github.com/jhatler/janus/issues/9)) ([e900bd9](https://github.com/jhatler/janus/commit/e900bd98b4221022b0242448ed9f5ff36546d980)), closes [#8](https://github.com/jhatler/janus/issues/8)
-
-<!--- @generated --->
-## pyJanus Changelog

--- a/packages/janus.js/CHANGELOG.md
+++ b/packages/janus.js/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+# Janus.js Changelog
+<!--- @generated --->
+
 
 ## 0.1.0 (2024-05-27)
 
@@ -6,6 +8,3 @@
 ### Features
 
 * Add devcontainer and other GitHub configs ([#9](https://github.com/jhatler/janus/issues/9)) ([e900bd9](https://github.com/jhatler/janus/commit/e900bd98b4221022b0242448ed9f5ff36546d980)), closes [#8](https://github.com/jhatler/janus/issues/8)
-
-<!--- @generated --->
-## Janus.js Changelog


### PR DESCRIPTION
This moves the pre-populated CHANGELOG headers to the correct location.

Fixes: #47