### PR TITLE
fix: mark release-trigger changelog as generated

### DIFF
--- a/packages/release-trigger/CHANGELOG.md
+++ b/packages/release-trigger/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Changelog
+# release-trigger Janus Fork Changelog
+<!--- @generated --->
+
 
 ## [1.1.0](https://github.com/jhatler/janus/compare/release-trigger (Janus Fork)-v1.0.0...release-trigger (Janus Fork)-v1.1.0) (2024-05-28)
 


### PR DESCRIPTION
The release-trigger changelog is generated by the release-please bot and should be marked as generated in the file.

Fixes: #64