### PR TITLE
chore: enable chores in release notes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,7 +46,7 @@
         {
             "type": "chore",
             "section": "Miscellaneous Chores",
-            "hidden": true
+            "hidden": false
         },
         {
             "type": "refactor",


### PR DESCRIPTION
This is helpful due to the amount of bot work ongoing.

Fixes: #117