### PR TITLE
chore: disable codeql and tfsec workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,6 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '39 7 * * 6'
 

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -3,8 +3,6 @@ name: tfsec
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '27 21 * * 6'
 


### PR DESCRIPTION
This is to work around a GitHub API rate limit issue that is causing PR checks to fail. This will be reverted once the rate limit issue is resolved or the backlog of PRs is cleared.

Refs: #119