### PR TITLE
chore: downgrade devenv to node 18

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus-devcontainer:v0.1.4", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus-devcontainer:v0.1", /* x-release-please-version */
     "remoteUser": "node",
     "containerUser": "node",
     "postCreateCommand": "docker pull ghcr.io/super-linter/super-linter:v6.5.1"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/actions/container
         with:
           context: "{{defaultContext}}:containers/janus"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           repository: ghcr.io/jhatler/janus
           registry: ghcr.io
@@ -105,7 +105,7 @@ jobs:
         uses: ./.github/actions/devcontainer
         with:
           workspace: ${{ github.workspace }}/devcontainers/janus
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           repository: ghcr.io/jhatler/janus-devcontainer
           registry: ghcr.io

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -125,5 +125,5 @@ jobs:
         shell: bash
         run: |
           devcontainer up --workspace-folder .
-          devcontainer exec --workspace-folder . /usr/local/share/nvm/versions/node/v22.2.0/bin/devcontainer --version
+          devcontainer exec --workspace-folder . /usr/local/share/nvm/versions/node/v18.17.0/bin/devcontainer --version
   # jscpd:ignore-end

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 18
           cache: 'npm'
 
       - name: Cache NPM dependencies

--- a/.github/workflows/release-trigger-ci.yml
+++ b/.github/workflows/release-trigger-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
           cache: 'npm'
 
       - name: Cache Dependencies
@@ -33,7 +33,7 @@ jobs:
           path: |
             node_modules
             packages/release-trigger/node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json,packages/release-trigger/package-lock.json') }}
+          key: ${{ runner.os }}-npm-v4-${{ hashFiles('package-lock.json,packages/release-trigger/package-lock.json') }}
 
       - name: Install release-trigger Dependencies
         if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 18
           cache: 'npm'
 
       - name: Cache Dependencies
@@ -64,7 +64,7 @@ jobs:
           path: |
             node_modules
             packages/release-trigger/node_modules
-          key: ${{ runner.os }}-npm-v3-${{ hashFiles('package-lock.json,packages/release-trigger/package-lock.json') }}
+          key: ${{ runner.os }}-npm-v4-${{ hashFiles('package-lock.json,packages/release-trigger/package-lock.json') }}
 
       - name: Run Tests
         run: npm test

--- a/containers/janus/Dockerfile
+++ b/containers/janus/Dockerfile
@@ -2,7 +2,7 @@
 #checkov:skip=CKV_DOCKER_2:Not applicable
 
 # Build stage
-FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm as build
+FROM mcr.microsoft.com/devcontainers/typescript-node:18-bookworm as build
 ARG TARGETARCH
 
 LABEL org.label-schema.schema-version="1.0"

--- a/devcontainers/janus/.devcontainer/devcontainer.json
+++ b/devcontainers/janus/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus:v0.1.4", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus:v0.1", /* x-release-please-version */
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"
@@ -21,7 +21,7 @@
             "version": "latest"
         },
         "ghcr.io/devcontainers/features/node:1": {
-            "version": "22"
+            "version": "18"
         },
         "ghcr.io/devcontainers/features/go:1": {
             "version": "latest"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "node": ">=18.0.0"
   },
   "devDependencies": {
-    "lerna": "^8.1.3",
-    "c8": "^7.1.0"
+    "lerna": "^8.1.3"
   },
   "workspaces": [
     "packages/*"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,7 +46,7 @@
         {
             "type": "chore",
             "section": "Miscellaneous Chores",
-            "hidden": true
+            "hidden": false
         },
         {
             "type": "refactor",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@tsconfig/node22/tsconfig.json"
+    "@tsconfig/node18/tsconfig.json"
   ],
   "include": [
     "packages/*/src/**/*",


### PR DESCRIPTION
This is to better support upgrading release-trigger.

Refs: #122