### PR TITLE
feat: sign containers

### DIFF
--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -38,12 +38,20 @@ inputs:
   password:
     description: 'OCI Registry Password'
     required: true
+  sign:
+    description: 'Sign images?'
+    required: false
+    default: false
 
 runs:
   using: "composite"
   steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+
+    - name: Install cosign
+      if: inputs.sign != 'false'
+      uses: sigstore/cosign-installer@v3.5.0
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -79,6 +87,19 @@ runs:
           ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
           ${{ inputs.repository }}:v${{ inputs.semver_major }}
         platforms: ${{ inputs.platforms }}
+
+    - name: Sign the published images
+      if: inputs.sign == 'true' && inputs.push == 'true'
+      shell: bash
+      env:
+        TAGS: |
+          ${{ inputs.repository }}:latest
+          ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }}
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }}
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}
+        DIGEST: ${{ steps.build.outputs.digest }}
+      run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
     - name: Attest
       uses: actions/attest-build-provenance@v1

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -43,12 +43,20 @@ inputs:
     description: 'Cleanup images after build?'
     required: true
     default: true
+  sign:
+    description: 'Sign images?'
+    required: false
+    default: false
 
 runs:
   using: "composite"
   steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+
+    - name: Install cosign
+      if: inputs.sign != 'false'
+      uses: sigstore/cosign-installer@v3.5.0
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -143,6 +151,19 @@ runs:
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
         docker push ${{ inputs.repository }}:v${{ inputs.semver_major }}
+
+    - name: Sign the published images
+      if: inputs.sign == 'true' && inputs.push == 'true'
+      shell: bash
+      env:
+        TAGS: |
+          ${{ inputs.repository }}:latest
+          ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }}
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}.${{ inputs.semver_patch }}
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}.${{ inputs.semver_minor }}
+          ${{ inputs.repository }}:v${{ inputs.semver_major }}
+        DIGEST: ${{ steps.tag.outputs.digest }}
+      run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
 
     # jscpd:ignore-start
     - name: Attest

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -9,6 +9,9 @@ on:
       - '!devcontainers/janus/CHANGELOG.md'
       - '.devcontainer/**'
       - '!.devcontainer/CHANGELOG.md'
+      - '.github/workflows/containers.yml'
+      - '.github/actions/container/**'
+      - '.github/actions/devcontainer/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -57,6 +60,7 @@ jobs:
           context: "{{defaultContext}}:containers/janus"
           platforms: linux/amd64,linux/arm64
           push: true
+          sign: true
           repository: ghcr.io/jhatler/janus
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -107,6 +111,7 @@ jobs:
           workspace: ${{ github.workspace }}/devcontainers/janus
           platforms: linux/amd64,linux/arm64
           push: true
+          sign: true
           repository: ghcr.io/jhatler/janus-devcontainer
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,6 +36,7 @@ jobs:
           context: "{{defaultContext}}:containers/janus"
           platforms: linux/amd64
           push: true
+          sign: true
           repository: ghcr.io/jhatler/janus
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -53,6 +54,7 @@ jobs:
           workspace: ${{ github.workspace }}/devcontainers/janus
           platforms: linux/amd64
           push: true
+          sign: true
           repository: ghcr.io/jhatler/janus-devcontainer
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/devcontainers/janus/.devcontainer/devcontainer.json
+++ b/devcontainers/janus/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus:v0.1.4", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus:v0.2.0-janusjsv01146gabcf339.46.abcf339", /* x-release-please-version */
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"


### PR DESCRIPTION
This adds container signing based on the GitHub Actions OpenID token, cosign, and Rekor. The signing is taken care of in the actions, and the workflows simply pass in a flag to enable it.

Fixes: #126