### PR TITLE
feat: use GitHub Action cache in container actions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus-devcontainer:v0.1.4", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus-devcontainer:v0", /* x-release-please-version */
     "remoteUser": "node",
     "containerUser": "node",
     "postCreateCommand": "docker pull ghcr.io/super-linter/super-linter:v6.5.1"

--- a/.github/actions/container/action.yml
+++ b/.github/actions/container/action.yml
@@ -76,8 +76,8 @@ runs:
         DOCKER_BUILDKIT: 1
         BUILDKIT_INLINE_CACHE: 1
       with:
-        cache-from: type=registry,ref=${{ inputs.repository }}
-        cache-to: type=inline
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         context: ${{ inputs.context }}
         push: ${{ inputs.push }}
         tags: |

--- a/.github/actions/devcontainer/action.yml
+++ b/.github/actions/devcontainer/action.yml
@@ -122,8 +122,8 @@ runs:
       run: |
         devcontainer build \
           --workspace-folder ${{ inputs.workspace }} \
-          --cache-from ${{ inputs.repository }} \
-          --cache-to type=inline \
+          --cache-from type=gha \
+          --cache-to type=gha,mode=max \
           --platform ${{ inputs.platforms }} \
           --image-name ${{ inputs.repository }}:${{ steps.git.outputs.short_sha }} \
           --output type=image,name=${{ inputs.repository }}:${{ steps.git.outputs.short_sha }},push=${{ inputs.push }}

--- a/devcontainers/janus/.devcontainer/devcontainer.json
+++ b/devcontainers/janus/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devContainer.schema.json",
-    "image": "ghcr.io/jhatler/janus:v0.2.0-janusjsv01146gabcf339.46.abcf339", /* x-release-please-version */
+    "image": "ghcr.io/jhatler/janus:v0", /* x-release-please-version */
     "features": {
         "ghcr.io/devcontainers/features/sshd:1": {
             "version": "latest"


### PR DESCRIPTION
This replaces the usage of the inline cache in the container actions.

Fixes: #128