### PR TITLE
chore(deps): release-trigger typescript update to 5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint": "<9.0.0",
         "eslint-plugin-jsonc": "<2.16.0",
         "prettier": "<3.2.0",
-        "typescript": "<5.2.0"
+        "typescript": "^5.3.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -7923,9 +7923,9 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -8260,7 +8260,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.12.12",
-        "typescript": "<5.2.0"
+        "typescript": "^5.3.0"
       }
     },
     "packages/release-trigger": {
@@ -8286,7 +8286,7 @@
         "nock": "^13.2.9",
         "sinon": "^18.0.0",
         "smee-client": "^2.0.0",
-        "typescript": "<5.2.0"
+        "typescript": "^5.3.0"
       },
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "eslint": "<9.0.0",
     "eslint-plugin-jsonc": "<2.16.0",
     "prettier": "<3.2.0",
-    "typescript": "<5.2.0"
+    "typescript": "^5.3.0"
   },
   "workspaces": [
     "packages/*"

--- a/packages/janus.js/package.json
+++ b/packages/janus.js/package.json
@@ -20,6 +20,6 @@
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.12.12",
-    "typescript": "<5.2.0"
+    "typescript": "^5.3.0"
   }
 }

--- a/packages/release-trigger/package.json
+++ b/packages/release-trigger/package.json
@@ -47,7 +47,7 @@
     "nock": "^13.2.9",
     "sinon": "^18.0.0",
     "smee-client": "^2.0.0",
-    "typescript": "<5.2.0"
+    "typescript": "^5.3.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
This updates typescript to 5.2 for release-trigger.

Its version pins in package.json were also refined.