### PR TITLE
fix: run release-trigger wf only on relevant PRs

### DIFF
--- a/.github/workflows/release-trigger-ci.yml
+++ b/.github/workflows/release-trigger-ci.yml
@@ -2,6 +2,11 @@ name: release-trigger CI
 
 on:
   pull_request:
+    paths:
+      - 'packages/release-trigger/**'
+      - '.github/workflows/release-trigger-ci.yml'
+      - 'package-lock.json'
+      - 'package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This restricts the release-trigger workflow to only run on PRs that modify the release-trigger package or its supporting files.

Fixes: #161