### PR TITLE
feat: add OpenSSF Best Practices badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 <!-- editorconfig-checker-disable -->
 [![GitHub License](https://img.shields.io/github/license/jhatler/janus)](LICENSE)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9031/badge)](https://www.bestpractices.dev/projects/9031)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jhatler/janus/badge)](https://scorecard.dev/viewer/?uri=github.com/jhatler/janus)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/aa0ce1f1ebf74b55a448c095012e391c)](https://app.codacy.com/gh/jhatler/janus/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
-[![Semantic Versioning](https://img.shields.io/badge/Semantic%20Versioning-2.0.0-3F4551?logo=semver&logoColor=white)](https://semver.org)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 <!-- editorconfig-checker-enable -->
 


### PR DESCRIPTION
This also removes the Semantic Versioning badge, as it is included in the OpenSSF Best Practices.

Fixes: #154