### PR TITLE
chore: remove license badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # Just Another Neural Utility System
 
 <!-- editorconfig-checker-disable -->
-[![GitHub License](https://img.shields.io/github/license/jhatler/janus)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9031/badge)](https://www.bestpractices.dev/projects/9031)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jhatler/janus/badge)](https://scorecard.dev/viewer/?uri=github.com/jhatler/janus)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/aa0ce1f1ebf74b55a448c095012e391c)](https://app.codacy.com/gh/jhatler/janus/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)


### PR DESCRIPTION
This is redundant with the License header that GitHub displays at the top of the README. It also doesn't add much value to the README.

Refs: #154