### PR TITLE
feat: give terraform resources their own releases

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,10 @@
   "devcontainers/janus": "0.1.4",
   "packages/janus.js": "0.1.1",
   "lib/pyjanus": "0.1.1",
-  "packages/release-trigger": "1.1.0"
+  "packages/release-trigger": "1.1.0",
+  "terraform": "0.0.0",
+  "terraform/control": "0.0.0",
+  "terraform/modules": "0.0.0",
+  "terraform/stacks": "0.0.0",
+  "terraform/stacks/hello-world": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -116,6 +116,26 @@
                     "path": ".devcontainer/devcontainer.json"
                 }
             ]
+        },
+        "terraform": {
+            "release-type": "simple",
+            "package-name": "tf-root"
+        },
+        "terraform/control": {
+            "release-type": "simple",
+            "package-name": "tf-control"
+        },
+        "terraform/modules": {
+            "release-type": "simple",
+            "package-name": "tf-modules"
+        },
+        "terraform/stacks": {
+            "release-type": "simple",
+            "package-name": "tf-stacks"
+        },
+        "terraform/stacks/hello_world": {
+            "release-type": "simple",
+            "package-name": "tf-stack-hello_world"
         }
     }
 }

--- a/terraform/control/main.tf
+++ b/terraform/control/main.tf
@@ -5,7 +5,7 @@ resource "spacelift_stack" "hello-world" {
   branch            = "main"
   description       = "Hello World Stack"
   name              = "Hello World"
-  project_root      = "terraform/stacks/hello-world"
+  project_root      = "terraform/stacks/hello_world"
   repository        = "janus"
   terraform_version = "1.5.7"
 }

--- a/terraform/stacks/hello-world/main.tf
+++ b/terraform/stacks/hello-world/main.tf
@@ -1,4 +1,0 @@
-resource "spacelift_context" "hello-world" {
-  description = "Hello World Context"
-  name        = "Hello World"
-}

--- a/terraform/stacks/hello-world/providers.tf
+++ b/terraform/stacks/hello-world/providers.tf
@@ -1,9 +1,0 @@
-terraform {
-  required_providers {
-    spacelift = {
-      source  = "spacelift-io/spacelift"
-      version = "1.13.1"
-    }
-  }
-}
-provider "spacelift" {}


### PR DESCRIPTION
This adds a top-level `tf-root` package to release-please, which will encompass all terraform resources. There are nested packages within it, for `tf-stacks` and `tf-modules` which will contain further nested packages for each stack and module, respectively. Finally, there is a `tf-control` package which will contain the stack definitions for Spacelift.

Fixes #183
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>