### PR TITLE
fix: hello_world spacelift stack is administrative

### DIFF
--- a/terraform/control/main.tf
+++ b/terraform/control/main.tf
@@ -1,6 +1,6 @@
 # Initial stack to test integrations
 resource "spacelift_stack" "hello-world" {
-  administrative    = false
+  administrative    = true
   autodeploy        = true
   branch            = "main"
   description       = "Hello World Stack"


### PR DESCRIPTION
This makes the hello_world spacelift stack administrative so that it can create the necessary resources in the spacelift account.

Fixes: #198