### PR TITLE
fix: publish arm64 containers during release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/container
         with:
           context: "{{defaultContext}}:containers/janus"
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           sign: true
           repository: ghcr.io/jhatler/janus


### PR DESCRIPTION
Prior to this, only CI builds created arm64 containers. This change updates the release-please workflow to publish arm64 containers as well.

The devcontainers will need updated in a different commit once a release of arm64 containers is made.

Refs: #203