### PR TITLE
chore: migrate to opencontainer labels

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/container
         with:
           context: "{{defaultContext}}:containers/janus"
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           sign: true
           repository: ghcr.io/jhatler/janus
@@ -109,7 +109,7 @@ jobs:
         uses: ./.github/actions/devcontainer
         with:
           workspace: ${{ github.workspace }}/devcontainers/janus
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           sign: true
           repository: ghcr.io/jhatler/janus-devcontainer

--- a/containers/janus/Dockerfile
+++ b/containers/janus/Dockerfile
@@ -3,11 +3,11 @@
 FROM mcr.microsoft.com/devcontainers/typescript-node:22-bookworm as build
 ARG TARGETARCH
 
-LABEL org.label-schema.schema-version="1.0"
-LABEL maintainer="Jaremy Hatler <hatler.jaremy@gmail.com>"
-LABEL org.opencontainers.image.source="https://github.com/jhatler/janus"
+LABEL org.opencontainers.image.authors="Jaremy Hatler <hatler.jaremy@gmail.com>"
 LABEL org.opencontainers.image.description="Just Another Nueral Utility System"
 LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/jhatler/janus/tree/main/containers/janus"
+LABEL org.opencontainers.image.source="https://github.com/jhatler/janus"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-c"]
 ENV SHELL=/bin/bash


### PR DESCRIPTION
This removes label-schema labels from the Janus container and replaces them with OpenContainer labels.

Fixes: #207