### PR TITLE
feat: add packer to build runner AMI

### DIFF
--- a/.github/workflows/packer.yml
+++ b/.github/workflows/packer.yml
@@ -1,0 +1,59 @@
+---
+name: "Packer Builds"
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packer/**'
+      - '.github/workflows/packer.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packer/**'
+      - '.github/workflows/packer.yml'
+  schedule:
+    - cron: '0 0 */14 * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  runner:
+    name: runner-${{ matrix.arch }}
+    runs-on: aws:ec2launchtemplate:runner-arm64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            source: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*'
+            owner: amazon
+          - arch: amd64
+            source: 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*'
+            owner: amazon
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create AMI
+        shell: bash
+        id: ami-publish
+        env:
+          PKR_VAR_source_ami_prefix: ${{ matrix.source }}
+          PKR_VAR_source_ami_owner: ${{ matrix.owner }}
+          PKR_VAR_instance_type: ${{ matrix.arch == 'arm64' && 'c7g.large' || 'c7i.large' }}
+          PKR_VAR_aws_region: us-east-2
+          PKR_VAR_iam_instance_profile: runner-controlled
+          PKR_VAR_ami_name: runner-${{ matrix.arch }}
+          PKR_VAR_runner_name: runner
+        working-directory: packer/runner
+        run: |
+          /usr/bin/env packer init ami.pkr.hcl
+          /usr/bin/env packer build -machine-readable -on-error=cleanup ami.pkr.hcl

--- a/packer/runner/.gitignore
+++ b/packer/runner/.gitignore
@@ -1,0 +1,16 @@
+# Cache objects
+packer_cache/
+
+# Crash and other logs
+*.log
+
+# https://www.packer.io/guides/hcl/variables
+# Exclude all .pkrvars.hcl files, which are likely to contain sensitive data,
+# such as password, private keys, and other secrets. These should not be part of
+# version control as they are data points which are potentially sensitive and
+# subject to change depending on the environment.
+#
+*.pkrvars.hcl
+
+# For built boxes
+*.box

--- a/packer/runner/ami.pkr.hcl
+++ b/packer/runner/ami.pkr.hcl
@@ -1,0 +1,127 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+    ansible = {
+      version = "~> 1"
+      source = "github.com/hashicorp/ansible"
+    }
+  }
+}
+
+variable "source_ami_prefix" {
+  type    = string
+}
+
+variable "source_ami_owner" {
+  type    = string
+}
+
+variable "instance_type" {
+  type    = string
+}
+
+variable "aws_region" {
+  type    = string
+}
+
+variable "iam_instance_profile" {
+  type    = string
+}
+
+variable "ami_name" {
+  type    = string
+}
+
+variable "runner_name" {
+  type    = string
+}
+
+data "amazon-ami" "source" {
+    filters = {
+        virtualization-type = "hvm"
+        name = var.source_ami_prefix
+        root-device-type = "ebs"
+    }
+    owners = [var.source_ami_owner]
+    most_recent = true
+    region =  "${var.aws_region}"
+
+}
+
+source "amazon-ebs" "runner" {
+  region =  "${var.aws_region}"
+  instance_type =  "${var.instance_type}"
+
+  ami_name =  "${var.ami_name} {{timestamp}}"
+
+  source_ami =  data.amazon-ami.source.id
+  ssh_username =  "ubuntu"
+
+  iam_instance_profile =  "${var.iam_instance_profile}"
+
+  user_data_file = "files/cloud-config.txt"
+
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 64
+    volume_type = "gp3"
+    delete_on_termination = true
+  }
+
+  run_tags = {
+    "Name" = "Packer: ${var.ami_name} {{timestamp}}"
+  }
+
+  run_volume_tags = {
+    "Name" = "Packer: ${var.ami_name} {{timestamp}}"
+  }
+
+  snapshot_tags = {
+    "Name" = "${var.ami_name} {{timestamp}}"
+  }
+
+  tags = {
+    "Name" = "${var.ami_name} {{timestamp}}"
+    "auth.gh-oidc" = "true"
+  }
+}
+
+build {
+  sources = [
+    "amazon-ebs.runner"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "sudo rm -rf /setup",
+      "sudo mkdir /setup",
+      "sudo chown ubuntu:ubuntu /setup"
+    ]
+  }
+
+  provisioner "file" {
+    source      = "scripts"
+    destination = "/setup"
+  }
+
+  provisioner "shell" {
+    inline = [
+      "echo 'Waiting for cloud-init...'; cloud-init status --wait"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo -i /setup/scripts/test.sh"
+    ]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "sudo -i /setup/scripts/clean.sh"
+    ]
+  }
+}

--- a/packer/runner/files/cloud-config.txt
+++ b/packer/runner/files/cloud-config.txt
@@ -1,0 +1,20 @@
+#cloud-config
+system_info:
+  default_user:
+    uid: 5000
+manage_etc_hosts: true
+users:
+  - default
+package_upgrade: false
+package_update: false
+apt_pipelining: false
+apt:
+  sources_list: |
+    deb $MIRROR $RELEASE main universe multiverse restricted
+    deb-src $MIRROR $RELEASE main universe multiverse restricted
+    deb $MIRROR $RELEASE-updates main universe multiverse restricted
+    deb-src $MIRROR $RELEASE-updates main universe multiverse restricted
+    deb $MIRROR $RELEASE-backports main universe multiverse restricted
+    deb-src $MIRROR $RELEASE-backports main universe multiverse restricted
+    deb $SECURITY $RELEASE-security main universe multiverse restricted
+    deb-src $SECURITY $RELEASE-security main universe multiverse restricted

--- a/packer/runner/scripts/clean.sh
+++ b/packer/runner/scripts/clean.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+cloud-init clean --logs --machine-id --configs all
+rm -f /etc/sudoers.d/90-cloud-init-users
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+find /var/cache/apt -type f -print0 | xargs -0 rm -f
+touch -d '1970-01-01 0:00:00' /var/lib/apt/lists
+
+# Stop the journal, clear machine-specific logs, and truncate the rest
+systemctl stop systemd-journald.service systemd-journald{,-dev-log,-audit}.socket
+rm -rf /var/log/journal/* /var/log/amazon/ssm/audits/* /var/log/apt/*
+find /var/log -type f -print0 | xargs -0 truncate --size=0
+
+# Clear the tmp directories
+find /var/tmp /tmp -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} \;
+
+# Recommended by systemd for imaging
+rm -f /var/lib/systemd/random-seed /etc/hostname
+
+# Prevent known host or key issues
+rm -f /etc/ssh/ssh_host_* /root/.ssh/authorized_keys
+
+# Delete the setup files
+rm -rf /setup
+
+# Deletes the ubuntu group too
+# No sudo after this, including in packer provisioners
+userdel -rf ubuntu

--- a/packer/runner/scripts/test.sh
+++ b/packer/runner/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -ex -o pipefail
+
+exit 0


### PR DESCRIPTION
This adds a packer/ directory to the repository that will house the files related to building machine images using Packer. The first machine image that has been added is a starting point for a GitHub Actions runner. This image is based on Ubuntu 22.04 and doesn't receive any configuration at this time. That will be added in subsequent commits.

This commit also adds a GitHub Actions workflow that will build the runner AMI using Packer. This workflow is triggered by updates to the packer/ directory (PR and push events). It also will run every 2 weeks to ensure that the runner AMI is kept up to date.

Refs: #273