### PR TITLE
feat: Spacelift AWS integrations are self-managed

### DIFF
--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -22,7 +22,7 @@ jobs:
         include:
           - working_directory: terraform/control
             sarif_file: tfsec-control.sarif
-          - tfpath: terraform/stacks/hello-world
+          - tfpath: terraform/stacks/hello_world
             sarif_file: tfsec-hello-world.sarif
     steps:
       - name: Clone repo

--- a/terraform/control/aws.tf
+++ b/terraform/control/aws.tf
@@ -1,0 +1,100 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  control_role_name = "spacelift-control"
+  control_role_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.control_role_name}"
+  stack_role_name   = "spacelift-stacks"
+  stack_role_arn    = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.stack_role_name}"
+}
+
+##
+## Control Stack Setup
+##
+
+resource "spacelift_aws_integration" "control" {
+  name = local.control_role_name
+
+  # We need to set this manually rather than referencing the role to avoid a circular dependency
+  role_arn                       = local.control_role_arn
+  generate_credentials_in_worker = false
+}
+
+# The spacelift_aws_integration_attachment_external_id data source is
+# used to help generate a trust policy for the integration
+data "spacelift_aws_integration_attachment_external_id" "control" {
+  integration_id = spacelift_aws_integration.control.id
+  stack_id       = spacelift_stack.control.id
+  read           = true
+  write          = true
+}
+
+resource "aws_iam_role" "control" {
+  name = local.control_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      jsondecode(data.spacelift_aws_integration_attachment_external_id.control.assume_role_policy_statement),
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "control" {
+  # it may be possible to reduce this in the future
+  # checkov:skip=CKV_AWS_274:Only the Control stack should have AdministratorAccess
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  role       = aws_iam_role.control.name
+}
+
+resource "spacelift_aws_integration_attachment" "control" {
+  integration_id = spacelift_aws_integration.control.id
+  stack_id       = spacelift_stack.control.id
+  read           = true
+  write          = true
+
+  # The role needs to exist before we attach since we test role assumption during attachment.
+  depends_on = [
+    aws_iam_role.control
+  ]
+}
+
+##
+## Child Stack Setup
+##
+resource "spacelift_aws_integration" "integration" {
+  name = local.stack_role_name
+
+  # We need to set this manually rather than referencing the role to avoid a circular dependency
+  role_arn                       = local.stack_role_arn
+  generate_credentials_in_worker = false
+}
+
+resource "aws_iam_role" "integration" {
+  name = local.stack_role_name
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        "Principal" = {
+          "AWS" : data.spacelift_account.current.aws_account_id
+        },
+        "Action" = "sts:AssumeRole",
+        "Condition" = {
+          "StringEquals" = {
+            # Allow the external ID for any of the stacks to assume our role
+            "sts:ExternalId" = [
+              for i in values(data.spacelift_aws_integration_attachment_external_id.integration) : i.external_id
+            ],
+          }
+        }
+      }
+    ],
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "integration" {
+  policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
+  role       = aws_iam_role.integration.name
+}

--- a/terraform/control/main.tf
+++ b/terraform/control/main.tf
@@ -1,11 +1,19 @@
-# Initial stack to test integrations
-resource "spacelift_stack" "hello-world" {
-  administrative    = true
-  autodeploy        = true
+data "spacelift_account" "current" {}
+
+# This is the control stack we are currently in
+resource "spacelift_stack" "control" {
+  administrative        = true
+  autodeploy            = true
+  protect_from_deletion = true
+
+  github_action_deploy = false
+
+  enable_well_known_secret_masking = true
+
   branch            = "main"
-  description       = "Hello World Stack"
-  name              = "Hello World"
-  project_root      = "terraform/stacks/hello_world"
+  description       = "Control Stack"
+  name              = "Control"
+  project_root      = "terraform/control"
   repository        = "janus"
   terraform_version = "1.5.7"
 }

--- a/terraform/control/providers.tf
+++ b/terraform/control/providers.tf
@@ -1,1 +1,6 @@
 provider "spacelift" {}
+
+provider "aws" {
+  alias  = "us-east-2"
+  region = "us-east-2"
+}

--- a/terraform/control/stacks.tf
+++ b/terraform/control/stacks.tf
@@ -1,0 +1,53 @@
+locals {
+  stacks_to_create = [
+    {
+      name         = "Hello World"
+      description  = "Hello World Stack"
+      project_root = "terraform/stacks/hello_world"
+      id           = "hello-world"
+    }
+  ]
+}
+
+resource "spacelift_stack" "children" {
+  for_each = { for stack in local.stacks_to_create : stack.name => stack }
+
+  administrative = true
+  autodeploy     = true
+
+  github_action_deploy = false
+
+  enable_well_known_secret_masking = true
+
+  branch            = "main"
+  repository        = "janus"
+  terraform_version = "1.5.7"
+
+  description  = each.value.description
+  name         = each.value.name
+  project_root = each.value.project_root
+}
+
+# Generate the External IDs required for creating our AssumeRole policy
+data "spacelift_aws_integration_attachment_external_id" "integration" {
+  for_each = { for stack in local.stacks_to_create : stack.name => stack }
+
+  integration_id = spacelift_aws_integration.integration.id
+  stack_id       = each.value.id
+  read           = true
+  write          = true
+}
+
+resource "spacelift_aws_integration_attachment" "integration" {
+  for_each = { for stack in local.stacks_to_create : stack.name => stack }
+
+  integration_id = spacelift_aws_integration.integration.id
+  stack_id       = each.value.id
+  read           = true
+  write          = true
+
+  # The role needs to exist before we attach since we test role assumption during attachment.
+  depends_on = [
+    aws_iam_role.integration
+  ]
+}

--- a/terraform/control/versions.tf
+++ b/terraform/control/versions.tf
@@ -4,5 +4,9 @@ terraform {
       source  = "spacelift-io/spacelift"
       version = "1.14.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.52.0"
+    }
   }
 }


### PR DESCRIPTION
This extends the Spacelift control stack to include the ability to configure the AWS integration. This is done by adding a new `aws.tf' file that contains the necessary configuration for the AWS integration.

All child stacks have been moved to `stacks.tf` and this is where the per-stack AWS Integration configuration will be done.

Refs: #279