### PR TITLE
fix: remove alias from AWS provider

### DIFF
--- a/terraform/control/providers.tf
+++ b/terraform/control/providers.tf
@@ -1,6 +1,5 @@
 provider "spacelift" {}
 
 provider "aws" {
-  alias  = "us-east-2"
   region = "us-east-2"
 }


### PR DESCRIPTION
This removes the alias from the AWS provider in the control stack. This is an attempt to resolve the current Spacelift failures.

Refs: #282