### PR TITLE
fix: Spacelift determines control repo via context

### DIFF
--- a/terraform/control/main.tf
+++ b/terraform/control/main.tf
@@ -10,10 +10,16 @@ resource "spacelift_stack" "control" {
 
   enable_well_known_secret_masking = true
 
+  labels = [
+    "admin",
+    "aikido",
+    "infracost"
+  ]
+
   branch            = "main"
   description       = "Control Stack"
   name              = "Control"
   project_root      = "terraform/control"
-  repository        = "janus"
+  repository        = var.control_repository
   terraform_version = "1.5.7"
 }

--- a/terraform/control/stacks.tf
+++ b/terraform/control/stacks.tf
@@ -12,20 +12,26 @@ locals {
 resource "spacelift_stack" "children" {
   for_each = { for stack in local.stacks_to_create : stack.name => stack }
 
-  administrative = true
+  administrative = false
   autodeploy     = true
 
   github_action_deploy = false
 
   enable_well_known_secret_masking = true
 
+  repository = var.control_repository
+
   branch            = "main"
-  repository        = "janus"
   terraform_version = "1.5.7"
 
   description  = each.value.description
   name         = each.value.name
   project_root = each.value.project_root
+
+  labels = [
+    "infracost",
+    "aikido"
+  ]
 }
 
 # Generate the External IDs required for creating our AssumeRole policy

--- a/terraform/control/variables.tf
+++ b/terraform/control/variables.tf
@@ -1,0 +1,3 @@
+variable "control_repository" {
+  type = string
+}


### PR DESCRIPTION
This removes the hardcoded `janus` repo from the Spacelift stack configs and replaces them with the `control_repository` Terraform variable.

This variable will need to be exposed to the stack via a Context or Stack environment config.

Refs: #284