### PR TITLE
fix: apply cloud integrations after stack create

### DIFF
--- a/terraform/control/stacks.tf
+++ b/terraform/control/stacks.tf
@@ -42,6 +42,10 @@ data "spacelift_aws_integration_attachment_external_id" "integration" {
   stack_id       = each.value.id
   read           = true
   write          = true
+
+  depends_on = [
+    spacelift_stack.children
+  ]
 }
 
 resource "spacelift_aws_integration_attachment" "integration" {
@@ -54,6 +58,7 @@ resource "spacelift_aws_integration_attachment" "integration" {
 
   # The role needs to exist before we attach since we test role assumption during attachment.
   depends_on = [
+    spacelift_stack.children,
     aws_iam_role.integration
   ]
 }


### PR DESCRIPTION
This updates the dependencies in the Spacelift control stack to ensure that the cloud integrations are not added to a child stack until after the stack has been created. This is necessary because the name of the stacks is being defined via a local varable and not a resource attribute.

Refs: #286