### PR TITLE
feat: Add GitHub OIDC Terraform Module

### DIFF
--- a/terraform/control/modules.tf
+++ b/terraform/control/modules.tf
@@ -1,0 +1,21 @@
+locals {
+  modules_to_create = [
+    {
+      name         = "github-oidc"
+      description  = "Configures GitHub access to IAM Role via OIDC"
+      project_root = "terraform/modules/github_oidc"
+    }
+  ]
+}
+
+resource "spacelift_module" "github_oidc" {
+  for_each = { for module in local.modules_to_create : module.name => module }
+
+  terraform_provider = "aws"
+  branch             = "main"
+  repository         = var.control_repository
+
+  name         = each.key
+  description  = each.value.description
+  project_root = each.value.project_root
+}

--- a/terraform/modules/github_oidc/.spacelift/config.yaml
+++ b/terraform/modules/github_oidc/.spacelift/config.yaml
@@ -1,0 +1,3 @@
+# The version of the configuration file format
+version: 1
+module_version: 0.1.0

--- a/terraform/modules/github_oidc/main.tf
+++ b/terraform/modules/github_oidc/main.tf
@@ -1,0 +1,42 @@
+# Per: https://github.com/aws-actions/configure-aws-credentials/blob/bd0758102444af2a09b9e47a2c93d0f091c1252d/README.md
+#   Note that the thumbprint below has been set to all F's because the thumbprint is not used
+#   when authenticating token.actions.githubusercontent.com. This is a special case used only
+#   when GitHub's OIDC is authenticating to IAM. IAM uses its library of trusted CAs to authenticate.
+resource "aws_iam_openid_connect_provider" "gh" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+}
+
+resource "aws_iam_role" "gh_oidc" {
+  name = "gh-oidc-${var.github_owner}--${var.github_repository}"
+
+  assume_role_policy = jsonencode({
+    Version = "2008-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Sid    = "AllowGitHubOIDC"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.gh.arn
+        }
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_owner}/${var.github_repository}:*"
+          }
+        }
+      }
+    ]
+  })
+
+  managed_policy_arns = var.role_policies
+}
+

--- a/terraform/modules/github_oidc/variables.tf
+++ b/terraform/modules/github_oidc/variables.tf
@@ -1,0 +1,14 @@
+variable "role_policies" {
+  type        = list(string)
+  description = "List of ARNs of IAM policies to attach to the OIDC role"
+}
+
+variable "github_owner" {
+  type        = string
+  description = "The owner of the GitHub repository to grant access to"
+}
+
+variable "github_repository" {
+  type        = string
+  description = "The name of the GitHub repository to grant access to"
+}

--- a/terraform/modules/github_oidc/versions.tf
+++ b/terraform/modules/github_oidc/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.52.0"
+    }
+  }
+}


### PR DESCRIPTION
This adds the ability for the Spacelift control stack to register modules in Spacelift. It does this to support adding the GitHub OIDC module, which grants AWS access to a GitHub repo by creating an IAM role (with the specified permissions) and applying a trust policy to it.

Refs: #288