### PR TITLE
feat: add network stack

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,10 @@ max_line_length = 72
 [TAG_EDITMSG]
 max_line_length = 72
 
+# Terraform files
+[*.tf]
+max_line_length = unset
+
 # Markdown files
 [*.md]
 max_line_length = unset

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
-    directory: "/terraform/stacks/hello-world/"
+    directory: "/terraform/stacks/hello_world/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/stacks/network/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -24,6 +24,8 @@ jobs:
             sarif_file: tfsec-control.sarif
           - tfpath: terraform/stacks/hello_world
             sarif_file: tfsec-hello-world.sarif
+          - tfpath: terraform/stacks/network
+            sarif_file: tfsec-hello-world.sarif
     steps:
       - name: Clone repo
         uses: actions/checkout@v4

--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -1,9 +1,10 @@
-resource "spacelift_stack_dependency" "hello_world__control" {
-  stack_id            = spacelift_stack.children["Hello World"].id
-  depends_on_stack_id = spacelift_stack.control.id
+resource "spacelift_stack_dependency" "network__admin" {
+  stack_id            = spacelift_stack.children["Network"].id
+  depends_on_stack_id = spacelift_stack.children["Admin"].id
 }
 
-resource "spacelift_stack_dependency" "admin__control" {
-  stack_id            = spacelift_stack.children["Admin"].id
-  depends_on_stack_id = spacelift_stack.control.id
+resource "spacelift_stack_dependency_reference" "network_s3_access_logs_bucket_id" {
+  stack_dependency_id = spacelift_stack_dependency.network__admin.id
+  output_name         = "s3_access_logs_bucket_id"
+  input_name          = "s3_access_logs_bucket_id"
 }

--- a/terraform/control/stacks.tf
+++ b/terraform/control/stacks.tf
@@ -11,6 +11,12 @@ locals {
       description  = "Central Administrative & Security Resources"
       project_root = "terraform/stacks/admin"
       id           = "admin"
+    },
+    {
+      name         = "Network"
+      description  = "Shared Network for all Stacks"
+      project_root = "terraform/stacks/network"
+      id           = "network"
     }
   ]
 }
@@ -37,6 +43,20 @@ resource "spacelift_stack" "children" {
   labels = [
     "infracost",
     "aikido"
+  ]
+}
+
+# Make all children dependent on the Control stack
+resource "spacelift_stack_dependency" "integration__control" {
+  for_each = { for stack in local.stacks_to_create : stack.name => stack }
+
+  stack_id            = each.value.id
+  depends_on_stack_id = spacelift_stack.control.id
+
+  # The children need to exist before their dependencies can be defined
+  depends_on = [
+    spacelift_stack.children,
+    spacelift_stack.control
   ]
 }
 

--- a/terraform/stacks/network/acls.tf
+++ b/terraform/stacks/network/acls.tf
@@ -1,0 +1,381 @@
+##
+## Public ACLs
+##
+resource "aws_network_acl" "public_edge" {
+  vpc_id = aws_vpc.primary.id
+
+  subnet_ids = [
+    aws_subnet.admin.id,
+    aws_subnet.public_edge_a.id,
+    aws_subnet.public_edge_b.id,
+    aws_subnet.public_edge_c.id
+  ]
+
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 100
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 20
+    to_port    = 20
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 200
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 21
+    to_port    = 21
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 300
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 22
+    to_port    = 22
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 400
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3389
+    to_port    = 3389
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 500
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  tags = {
+    Name = "Public Edge"
+  }
+}
+
+
+##
+## DMZ ACLs
+##
+resource "aws_network_acl" "dmz" {
+  vpc_id = aws_vpc.primary.id
+
+  subnet_ids = [
+    aws_subnet.dmz_a.id,
+    aws_subnet.dmz_b.id,
+    aws_subnet.dmz_c.id
+  ]
+
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "icmp"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = -1
+    icmp_type  = -1
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = aws_subnet.public_edge_a.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = aws_subnet.public_edge_b.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 300
+    action     = "allow"
+    cidr_block = aws_subnet.public_edge_c.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 400
+    action     = "allow"
+    cidr_block = aws_subnet.dmz_a.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 500
+    action     = "allow"
+    cidr_block = aws_subnet.dmz_b.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 600
+    action     = "allow"
+    cidr_block = aws_subnet.dmz_c.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 700
+    action     = "allow"
+    cidr_block = aws_subnet.internal_a.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 800
+    action     = "allow"
+    cidr_block = aws_subnet.internal_b.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 900
+    action     = "allow"
+    cidr_block = aws_subnet.internal_c.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 1000
+    action     = "allow"
+    cidr_block = aws_subnet.admin.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 1100
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3389
+    to_port    = 3389
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 1200
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  tags = {
+    Name = "DMZ"
+  }
+}
+
+##
+## Internal ACLs
+##
+resource "aws_network_acl" "internal" {
+  vpc_id = aws_vpc.primary.id
+
+  subnet_ids = [
+    aws_subnet.internal_a.id,
+    aws_subnet.internal_b.id,
+    aws_subnet.internal_c.id
+  ]
+
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "icmp"
+    rule_no    = 50
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "allow"
+    cidr_block = aws_subnet.dmz_a.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 200
+    action     = "allow"
+    cidr_block = aws_subnet.dmz_b.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 300
+    action     = "allow"
+    cidr_block = aws_subnet.dmz_c.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 400
+    action     = "allow"
+    cidr_block = aws_subnet.internal_a.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 500
+    action     = "allow"
+    cidr_block = aws_subnet.internal_b.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 600
+    action     = "allow"
+    cidr_block = aws_subnet.internal_c.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 700
+    action     = "allow"
+    cidr_block = aws_subnet.admin.cidr_block
+    from_port  = 0
+    to_port    = 0
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 900
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 3389
+    to_port    = 3389
+  }
+
+  ingress {
+    protocol   = "6"
+    rule_no    = 1000
+    action     = "allow"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 1024
+    to_port    = 65535
+    icmp_code  = 0
+    icmp_type  = 0
+  }
+
+  tags = {
+    Name = "Internal"
+  }
+}

--- a/terraform/stacks/network/cloudwatch.tf
+++ b/terraform/stacks/network/cloudwatch.tf
@@ -1,0 +1,7 @@
+# Cloudwatch Setup
+resource "aws_cloudwatch_log_group" "vpc_flow" {
+  name       = "vpc-flow"
+  kms_key_id = aws_kms_key.vpc_flow.arn
+
+  retention_in_days = 365
+}

--- a/terraform/stacks/network/eip.tf
+++ b/terraform/stacks/network/eip.tf
@@ -1,0 +1,9 @@
+# NAT Gateway
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "NAT Gateway"
+  }
+}
+

--- a/terraform/stacks/network/iam.tf
+++ b/terraform/stacks/network/iam.tf
@@ -1,0 +1,77 @@
+
+# Flow Logging
+data "aws_iam_policy_document" "vpc_flow" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vpc-flow-log/*"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:ListBucket",
+      "s3:DeleteObject",
+      "s3:GetBucketLocation",
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetEncryptionConfiguration",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads"
+    ]
+    resources = [
+      "arn:aws:s3:::vpc-flow-${data.aws_caller_identity.current.account_id}",
+      "arn:aws:s3:::vpc-flow-${data.aws_caller_identity.current.account_id}/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "vpc_flow_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "vpc_flow" {
+  name               = "vpc-flow"
+  assume_role_policy = data.aws_iam_policy_document.vpc_flow_assume_role.json
+}
+
+resource "aws_iam_role_policy" "vpc_flow" {
+  name   = "vpc-flow"
+  role   = aws_iam_role.vpc_flow.id
+  policy = data.aws_iam_policy_document.vpc_flow.json
+}

--- a/terraform/stacks/network/kms.tf
+++ b/terraform/stacks/network/kms.tf
@@ -1,0 +1,70 @@
+# Key to encrypt flows
+resource "aws_kms_key" "vpc_flow" {
+  description = "Used to encrypt captured VPC Flows"
+
+  enable_key_rotation = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "vpc-flow"
+    Statement = [
+      {
+        Sid    = "EnableIAMUserPermissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowCloudWatchUsage"
+        Effect = "Allow"
+        Principal = {
+          Service = "logs.${data.aws_region.current.name}.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:vpc-flow"
+          }
+        }
+      },
+      {
+        Sid    = "AllowVPCFlowLogsUsage"
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*",
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vpc-flow-log/*"
+          }
+          StringEquals = {
+            "aws:SourceAccount" : data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_kms_alias" "vpc_flow" {
+  name          = "alias/vpc-flow"
+  target_key_id = aws_kms_key.vpc_flow.key_id
+}

--- a/terraform/stacks/network/main.tf
+++ b/terraform/stacks/network/main.tf
@@ -1,0 +1,2 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/terraform/stacks/network/providers.tf
+++ b/terraform/stacks/network/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-2"
+}

--- a/terraform/stacks/network/routes.tf
+++ b/terraform/stacks/network/routes.tf
@@ -1,0 +1,105 @@
+##
+## Internet Gateway Route Table
+##
+resource "aws_route_table" "ig" {
+  vpc_id = aws_vpc.primary.id
+
+  tags = {
+    Name = "Internet Gateway"
+  }
+}
+
+resource "aws_route" "ig_gw" {
+  route_table_id         = aws_route_table.ig.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.primary.id
+  depends_on = [
+    aws_route_table.ig,
+    aws_internet_gateway.primary
+  ]
+}
+
+
+##
+## NAT Route Table
+##
+resource "aws_route_table" "nat" {
+  vpc_id = aws_vpc.primary.id
+
+  tags = {
+    Name = "NAT"
+  }
+}
+
+resource "aws_route" "nat_gw" {
+  route_table_id         = aws_route_table.nat.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.primary.id
+  depends_on = [
+    aws_route_table.nat,
+    aws_nat_gateway.primary
+  ]
+}
+
+
+##
+## Route Table Associations
+##
+
+# Main Table
+resource "aws_main_route_table_association" "primary" {
+  vpc_id         = aws_vpc.primary.id
+  route_table_id = aws_route_table.nat.id
+}
+
+
+# Per-Subnet Associations
+resource "aws_route_table_association" "admin" {
+  subnet_id      = aws_subnet.admin.id
+  route_table_id = aws_route_table.ig.id
+}
+
+resource "aws_route_table_association" "public_edge_a" {
+  subnet_id      = aws_subnet.public_edge_a.id
+  route_table_id = aws_route_table.ig.id
+}
+
+resource "aws_route_table_association" "public_edge_b" {
+  subnet_id      = aws_subnet.public_edge_b.id
+  route_table_id = aws_route_table.ig.id
+}
+
+resource "aws_route_table_association" "public_edge_c" {
+  subnet_id      = aws_subnet.public_edge_c.id
+  route_table_id = aws_route_table.ig.id
+}
+
+resource "aws_route_table_association" "dmz_a" {
+  subnet_id      = aws_subnet.dmz_a.id
+  route_table_id = aws_route_table.nat.id
+}
+
+resource "aws_route_table_association" "dmz_b" {
+  subnet_id      = aws_subnet.dmz_b.id
+  route_table_id = aws_route_table.nat.id
+}
+
+resource "aws_route_table_association" "dmz_c" {
+  subnet_id      = aws_subnet.dmz_c.id
+  route_table_id = aws_route_table.nat.id
+}
+
+resource "aws_route_table_association" "internal_a" {
+  subnet_id      = aws_subnet.internal_a.id
+  route_table_id = aws_route_table.nat.id
+}
+
+resource "aws_route_table_association" "internal_b" {
+  subnet_id      = aws_subnet.internal_b.id
+  route_table_id = aws_route_table.nat.id
+}
+
+resource "aws_route_table_association" "internal_c" {
+  subnet_id      = aws_subnet.internal_c.id
+  route_table_id = aws_route_table.nat.id
+}

--- a/terraform/stacks/network/s3.tf
+++ b/terraform/stacks/network/s3.tf
@@ -1,0 +1,83 @@
+# S3 Setup
+resource "aws_s3_bucket" "vpc_flow" {
+  #checkov:skip=CKV_AWS_144: The flow logs in this bucket do not need replicated across regions
+  #checkov:skip=CKV2_AWS_62: The flow logs do not require event notifications
+  bucket = "vpc-flow-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket_public_access_block" "vpc_flow" {
+  bucket = aws_s3_bucket.vpc_flow.id
+
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+  block_public_acls       = true
+  block_public_policy     = true
+}
+
+resource "aws_s3_bucket_logging" "vpc_flow" {
+  bucket = aws_s3_bucket.vpc_flow.id
+
+  target_bucket = var.s3_access_logs_bucket_id
+  target_prefix = "${aws_s3_bucket.vpc_flow.id}/"
+}
+
+resource "aws_s3_bucket_versioning" "vpc_flow" {
+  bucket = aws_s3_bucket.vpc_flow.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "vpc_flow" {
+  bucket = aws_s3_bucket.vpc_flow.id
+
+  rule {
+    id = "vpc-flows"
+
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    # A year of flow logs is kept in cloud watch, so these can move to IA/Glacier quickly
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+
+    # Keep flow logs for only 3 years
+    expiration {
+      days = 1095
+    }
+  }
+
+  # Flows shouldn't change, so expire versions quickly
+  # Really just here in case someone accidentally deletes something
+  rule {
+    id = "vpc-flow-versions"
+
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "vpc_flow" {
+  bucket = aws_s3_bucket.vpc_flow.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.vpc_flow.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}

--- a/terraform/stacks/network/subnets.tf
+++ b/terraform/stacks/network/subnets.tf
@@ -1,0 +1,124 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+##
+## Public Subnets
+##
+resource "aws_subnet" "admin" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.0.0/22"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "Admin"
+  }
+}
+
+resource "aws_subnet" "public_edge_a" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.16.0/22"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "Public Edge A"
+  }
+}
+
+resource "aws_subnet" "public_edge_b" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.20.0/22"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "Public Edge B"
+  }
+}
+
+resource "aws_subnet" "public_edge_c" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.24.0/22"
+  availability_zone = data.aws_availability_zones.available.names[2]
+
+  tags = {
+    Name = "Public Edge C"
+  }
+}
+
+
+##
+## DMZ Subnets
+##
+resource "aws_subnet" "dmz_a" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.80.0/22"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "DMZ A"
+  }
+}
+
+resource "aws_subnet" "dmz_b" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.84.0/22"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "DMZ B"
+  }
+}
+
+resource "aws_subnet" "dmz_c" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.88.0/22"
+  availability_zone = data.aws_availability_zones.available.names[2]
+
+  tags = {
+    Name = "DMZ C"
+  }
+}
+
+
+##
+## Public Subnets
+##
+resource "aws_subnet" "internal_a" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.160.0/22"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = "Internal A"
+  }
+}
+
+resource "aws_subnet" "internal_b" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.164.0/22"
+  availability_zone = data.aws_availability_zones.available.names[1]
+
+  tags = {
+    Name = "Internal B"
+  }
+}
+
+resource "aws_subnet" "internal_c" {
+  vpc_id = aws_vpc.primary.id
+
+  cidr_block        = "10.24.168.0/22"
+  availability_zone = data.aws_availability_zones.available.names[2]
+
+  tags = {
+    Name = "Internal C"
+  }
+}

--- a/terraform/stacks/network/variables.tf
+++ b/terraform/stacks/network/variables.tf
@@ -1,0 +1,4 @@
+variable "s3_access_logs_bucket_id" {
+  type        = string
+  description = "The ID of the S3 bucket to use for S3 access logs."
+}

--- a/terraform/stacks/network/versions.tf
+++ b/terraform/stacks/network/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.52.0"
+    }
+  }
+}

--- a/terraform/stacks/network/vpc.tf
+++ b/terraform/stacks/network/vpc.tf
@@ -1,0 +1,105 @@
+##
+## VPC and Misc. Resources
+##
+resource "aws_vpc" "primary" {
+  cidr_block       = "10.24.0.0/16"
+  instance_tenancy = "default"
+
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "Primary VPC"
+  }
+}
+
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.primary.id
+
+  tags = {
+    Name = "Default Rule - Deny All"
+  }
+}
+
+resource "aws_flow_log" "primary_cloudwatch" {
+  iam_role_arn    = aws_iam_role.vpc_flow.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.primary.id
+}
+
+resource "aws_flow_log" "primary_s3" {
+  iam_role_arn         = aws_iam_role.vpc_flow.arn
+  log_destination      = aws_s3_bucket.vpc_flow.arn
+  log_destination_type = "s3"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.primary.id
+}
+
+# Primary VPC default ACL
+resource "aws_default_network_acl" "primary" {
+  default_network_acl_id = aws_vpc.primary.default_network_acl_id
+
+  egress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  ingress {
+    protocol   = "-1"
+    rule_no    = 100
+    action     = "deny"
+    cidr_block = "0.0.0.0/0"
+    from_port  = 0
+    to_port    = 0
+  }
+
+  tags = {
+    Name = "Default ACL"
+  }
+}
+
+
+# Primary VPC Internet Gateway
+resource "aws_internet_gateway" "primary" {
+  vpc_id = aws_vpc.primary.id
+
+  tags = {
+    Name = "Primary-IG"
+  }
+}
+
+
+# Primary VPC DHCP Options
+resource "aws_vpc_dhcp_options" "primary" {
+  domain_name         = "${data.aws_region.current.name}.compute.internal"
+  domain_name_servers = ["AmazonProvidedDNS"]
+
+  tags = {
+    Name = "Default DHCP Options"
+  }
+}
+
+resource "aws_vpc_dhcp_options_association" "primary" {
+  vpc_id          = aws_vpc.primary.id
+  dhcp_options_id = aws_vpc_dhcp_options.primary.id
+}
+
+
+# Primary VPC NAT Gateway
+resource "aws_nat_gateway" "primary" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.admin.id
+
+  tags = {
+    Name = "Primary NAT Gateway"
+  }
+
+  # To ensure proper ordering, it is recommended to add an explicit dependency
+  # on the Internet Gateway for the VPC.
+  depends_on = [aws_internet_gateway.primary]
+}


### PR DESCRIPTION
This adds a simple network stack to Spacelift. It is intended to be shared by other stacks that need a VPC, subnets, etc. The VPC contains 10 subnets across 3 availability zones. The subnets are divided into public, DMZ, and internal subnets. The public subnets are intended for load balancers, NAT, etc. Applications should be placed in the DMZ, and data stores in the internal subnets.

Refs: #290