### PR TITLE
fix: remove alias from AWS provider

### DIFF
--- a/terraform/stacks/admin/providers.tf
+++ b/terraform/stacks/admin/providers.tf
@@ -1,4 +1,3 @@
 provider "aws" {
-  alias  = "us-east-2"
   region = "us-east-2"
 }


### PR DESCRIPTION
This is identical in nature to commit 6929f46 and removes the alias from the admin stack's AWS provider.

Refs: #282