### PR TITLE
fix: add TF_VAR_ prefix to spacelift dep refs

### DIFF
--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -5,6 +5,6 @@ resource "spacelift_stack_dependency" "network__admin" {
 
 resource "spacelift_stack_dependency_reference" "network_s3_access_logs_bucket_id" {
   stack_dependency_id = spacelift_stack_dependency.network__admin.id
-  output_name         = "s3_access_logs_bucket_id"
-  input_name          = "s3_access_logs_bucket_id"
+  output_name         = "TF_VAR_s3_access_logs_bucket_id"
+  input_name          = "TF_VAR_s3_access_logs_bucket_id"
 }

--- a/terraform/stacks/admin/output.tf
+++ b/terraform/stacks/admin/output.tf
@@ -1,4 +1,4 @@
-output "s3_access_logs_bucket_id" {
+output "TF_VAR_s3_access_logs_bucket_id" {
   value       = aws_s3_bucket.s3_access_logs.id
   description = "The ID of the S3 bucket to use for S3 access logs."
 }


### PR DESCRIPTION
This is needed for them to be properly interpolated by Terraform, and with it the deployments are broken.

Fixes: #312