### PR TITLE
fix: add crypto stack as a network dependency

### DIFF
--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -18,6 +18,11 @@ resource "spacelift_stack_dependency" "network__admin" {
   depends_on_stack_id = spacelift_stack.children["Admin"].id
 }
 
+resource "spacelift_stack_dependency" "network__crypto" {
+  stack_id            = spacelift_stack.children["Network"].id
+  depends_on_stack_id = spacelift_stack.children["Crypto"].id
+}
+
 resource "spacelift_stack_dependency_reference" "network_s3_access_logs_bucket_id" {
   stack_dependency_id = spacelift_stack_dependency.network__admin.id
   output_name         = "TF_VAR_s3_access_logs_bucket_id"
@@ -28,6 +33,12 @@ resource "spacelift_stack_dependency_reference" "network_vpc_flow_role_arn" {
   stack_dependency_id = spacelift_stack_dependency.network__auth.id
   output_name         = "TF_VAR_vpc_flow_role_arn"
   input_name          = "TF_VAR_vpc_flow_role_arn"
+}
+
+resource "spacelift_stack_dependency_reference" "network_vpc_flow_kms_key_arn" {
+  stack_dependency_id = spacelift_stack_dependency.network__crypto.id
+  output_name         = "TF_VAR_vpc_flow_kms_key_arn"
+  input_name          = "TF_VAR_vpc_flow_kms_key_arn"
 }
 
 resource "spacelift_stack_dependency_reference" "network_class_b_prefix" {


### PR DESCRIPTION
This was missing in the original commit, and is needed to enable VPC Flow loggin.

fixes: #322