### PR TITLE
fix: network IAM configuration

### DIFF
--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -46,3 +46,9 @@ resource "spacelift_stack_dependency_reference" "network_class_b_prefix" {
   output_name         = "TF_VAR_class_b_prefix"
   input_name          = "TF_VAR_class_b_prefix"
 }
+
+resource "spacelift_stack_dependency_reference" "network_stack_role_id" {
+  stack_dependency_id = spacelift_stack_dependency.network__auth.id
+  output_name         = "TF_VAR_stack_role_id"
+  input_name          = "TF_VAR_stack_role_id"
+}

--- a/terraform/control/output.tf
+++ b/terraform/control/output.tf
@@ -3,3 +3,9 @@ output "TF_VAR_class_b_prefix" {
   description = "The class B prefix for the VPC (e.g. 10.0)."
   sensitive   = true
 }
+
+output "TF_VAR_stack_role_id" {
+  value       = aws_iam_role.integration.arn
+  description = "The ID of the stack role."
+  sensitive   = true
+}

--- a/terraform/stacks/auth/network.tf
+++ b/terraform/stacks/auth/network.tf
@@ -79,3 +79,21 @@ resource "aws_iam_role_policy" "vpc_flow" {
   role   = aws_iam_role.vpc_flow.id
   policy = data.aws_iam_policy_document.vpc_flow.json
 }
+
+data "aws_iam_policy_document" "vpc_flow_attach" {
+  statement {
+    effect = "Allow"
+    sid    = "AllowFlowLogsRolePass"
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = [aws_iam_role.vpc_flow.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "vpc_flow_attach" {
+  name   = "vpc-flow-attach"
+  role   = var.stack_role_id
+  policy = data.aws_iam_policy_document.vpc_flow_attach.json
+}

--- a/terraform/stacks/auth/variables.tf
+++ b/terraform/stacks/auth/variables.tf
@@ -9,3 +9,9 @@ variable "control_owner" {
   type        = string
   description = "The owner of the GitHub repository for the control repository."
 }
+
+variable "stack_role_id" {
+  type        = string
+  description = "The ID of the stack role."
+  sensitive   = true
+}

--- a/terraform/stacks/network/vpc.tf
+++ b/terraform/stacks/network/vpc.tf
@@ -29,7 +29,6 @@ resource "aws_flow_log" "primary_cloudwatch" {
 }
 
 resource "aws_flow_log" "primary_s3" {
-  iam_role_arn         = var.vpc_flow_role_arn
   log_destination      = aws_s3_bucket.vpc_flow.arn
   log_destination_type = "s3"
   traffic_type         = "ALL"


### PR DESCRIPTION
This removes the erroneous IAM setting from the S3 flow configuration and grants stacks the ability to pass the vpc-flow role.

Fixes: #326