### PR TITLE
fix: output stack id instead of ARN

### DIFF
--- a/terraform/control/output.tf
+++ b/terraform/control/output.tf
@@ -5,7 +5,7 @@ output "TF_VAR_class_b_prefix" {
 }
 
 output "TF_VAR_stack_role_id" {
-  value       = aws_iam_role.integration.arn
+  value       = aws_iam_role.integration.id
   description = "The ID of the stack role."
   sensitive   = true
 }


### PR DESCRIPTION
This updates the control stack outputs.

Fixes: #331