### PR TITLE
fix: pass KMS key to runners stack

### DIFF
--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -23,6 +23,11 @@ resource "spacelift_stack_dependency" "network__crypto" {
   depends_on_stack_id = spacelift_stack.children["Crypto"].id
 }
 
+resource "spacelift_stack_dependency" "runners__crypto" {
+  stack_id            = spacelift_stack.children["Runners"].id
+  depends_on_stack_id = spacelift_stack.children["Crypto"].id
+}
+
 resource "spacelift_stack_dependency_reference" "network_s3_access_logs_bucket_id" {
   stack_dependency_id = spacelift_stack_dependency.network__admin.id
   output_name         = "TF_VAR_s3_access_logs_bucket_id"
@@ -55,6 +60,12 @@ resource "spacelift_stack_dependency_reference" "auth_stack_role_id" {
 
 resource "spacelift_stack_dependency_reference" "runners_runner_admin_pat" {
   stack_dependency_id = spacelift_stack_dependency.integration__control["Runners"].id
-  output_name         = "TF_VAR_runner_admin_pat"
-  input_name          = "TF_VAR_runner_admin_pat"
+  output_name         = "TF_VAR_runners_admin_pat"
+  input_name          = "TF_VAR_runners_admin_pat"
+}
+
+resource "spacelift_stack_dependency_reference" "runners_runners_kms_key_arn" {
+  stack_dependency_id = spacelift_stack_dependency.runners__crypto.id
+  output_name         = "TF_VAR_runners_kms_key_arn"
+  input_name          = "TF_VAR_runners_kms_key_arn"
 }

--- a/terraform/control/output.tf
+++ b/terraform/control/output.tf
@@ -10,8 +10,8 @@ output "TF_VAR_stack_role_id" {
   sensitive   = true
 }
 
-output "TF_VAR_runner_admin_pat" {
-  value       = var.runner_admin_pat
+output "TF_VAR_runners_admin_pat" {
+  value       = var.runners_admin_pat
   description = "The personal access token for runner admin."
   sensitive   = true
 }

--- a/terraform/control/variables.tf
+++ b/terraform/control/variables.tf
@@ -17,7 +17,7 @@ variable "class_b_prefix" {
   sensitive   = true
 }
 
-variable "runner_admin_pat" {
+variable "runners_admin_pat" {
   type        = string
   description = "The personal access token for runner admin."
   sensitive   = true

--- a/terraform/stacks/runners/params.tf
+++ b/terraform/stacks/runners/params.tf
@@ -1,11 +1,11 @@
-resource "aws_ssm_parameter" "runner_admin_token" {
+resource "aws_ssm_parameter" "runners_admin_token" {
   name   = "/github/actions/runners/admin-token"
   type   = "SecureString"
-  value  = var.runner_admin_pat
+  value  = var.runners_admin_pat
   key_id = var.runners_kms_key_arn
 }
 
-resource "aws_ssm_parameter" "runner_cooloff" {
+resource "aws_ssm_parameter" "runners_cooloff" {
   name   = "/github/actions/runners/cooloff"
   type   = "SecureString"
   value  = "10"

--- a/terraform/stacks/runners/variables.tf
+++ b/terraform/stacks/runners/variables.tf
@@ -16,7 +16,7 @@ variable "runners_kms_key_arn" {
   sensitive   = true
 }
 
-variable "runner_admin_pat" {
+variable "runners_admin_pat" {
   type        = string
   description = "The personal access token for runner admin."
   sensitive   = true


### PR DESCRIPTION
This was left out of the initial implementation, and caused the deployment to fail.

Fixes: #334