### PR TITLE
feat: always trigger stack deps

### DIFF
--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -62,58 +62,68 @@ resource "spacelift_stack_dependency_reference" "admin_apigateway_logs_role_arn"
   stack_dependency_id = spacelift_stack_dependency.admin__auth.id
   output_name         = "TF_VAR_apigateway_logs_role_arn"
   input_name          = "TF_VAR_apigateway_logs_role_arn"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "network_s3_access_logs_bucket_id" {
   stack_dependency_id = spacelift_stack_dependency.network__admin.id
   output_name         = "TF_VAR_s3_access_logs_bucket_id"
   input_name          = "TF_VAR_s3_access_logs_bucket_id"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "network_vpc_flow_role_arn" {
   stack_dependency_id = spacelift_stack_dependency.network__auth.id
   output_name         = "TF_VAR_vpc_flow_role_arn"
   input_name          = "TF_VAR_vpc_flow_role_arn"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "network_vpc_flow_kms_key_arn" {
   stack_dependency_id = spacelift_stack_dependency.network__crypto.id
   output_name         = "TF_VAR_vpc_flow_kms_key_arn"
   input_name          = "TF_VAR_vpc_flow_kms_key_arn"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "network_class_b_prefix" {
   stack_dependency_id = spacelift_stack_dependency.integration__control["Network"].id
   output_name         = "TF_VAR_class_b_prefix"
   input_name          = "TF_VAR_class_b_prefix"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "auth_stack_role_id" {
   stack_dependency_id = spacelift_stack_dependency.auth__control.id
   output_name         = "TF_VAR_stack_role_id"
   input_name          = "TF_VAR_stack_role_id"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "runners_runner_admin_pat" {
   stack_dependency_id = spacelift_stack_dependency.integration__control["Runners"].id
   output_name         = "TF_VAR_runners_admin_pat"
   input_name          = "TF_VAR_runners_admin_pat"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "runners_runners_kms_key_arn" {
   stack_dependency_id = spacelift_stack_dependency.runners__crypto.id
   output_name         = "TF_VAR_runners_kms_key_arn"
   input_name          = "TF_VAR_runners_kms_key_arn"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "webhooks_github_webhook_role_arn" {
   stack_dependency_id = spacelift_stack_dependency.webhooks__auth.id
   output_name         = "TF_VAR_github_webhook_role_arn"
   input_name          = "TF_VAR_github_webhook_role_arn"
+  trigger_always      = true
 }
 
 resource "spacelift_stack_dependency_reference" "webhooks_github_webhook_lambda_role_arn" {
   stack_dependency_id = spacelift_stack_dependency.webhooks__auth.id
   output_name         = "TF_VAR_github_webhook_lambda_role_arn"
   input_name          = "TF_VAR_github_webhook_lambda_role_arn"
+  trigger_always      = true
 }


### PR DESCRIPTION
This will ensure that the stack dependencies are always triggered, even if the outputs haven't changed. This is important for ensuring that the stacks behave as expected when they are used as dependencies.

Fixes: #347