### PR TITLE
fix: update runners/webhooks/ssm crypto access

### DIFF
--- a/terraform/control/deps.tf
+++ b/terraform/control/deps.tf
@@ -8,6 +8,11 @@ resource "spacelift_stack_dependency" "admin__auth" {
   depends_on_stack_id = spacelift_stack.auth.id
 }
 
+resource "spacelift_stack_dependency" "crypto__auth" {
+  stack_id            = spacelift_stack.children["Crypto"].id
+  depends_on_stack_id = spacelift_stack.auth.id
+}
+
 resource "spacelift_stack_dependency" "network__auth" {
   stack_id            = spacelift_stack.children["Network"].id
   depends_on_stack_id = spacelift_stack.auth.id
@@ -175,3 +180,32 @@ resource "spacelift_stack_dependency_reference" "runners_ssm_session_manager_buc
   input_name          = "TF_VAR_ssm_session_manager_bucket"
   trigger_always      = true
 }
+
+resource "spacelift_stack_dependency_reference" "crypto_runners_role_arn" {
+  stack_dependency_id = spacelift_stack_dependency.crypto__auth.id
+  output_name         = "TF_VAR_runners_role_arn"
+  input_name          = "TF_VAR_runners_role_arn"
+  trigger_always      = true
+}
+
+resource "spacelift_stack_dependency_reference" "crypto_runners_controlled_role_arn" {
+  stack_dependency_id = spacelift_stack_dependency.crypto__auth.id
+  output_name         = "TF_VAR_runners_controlled_role_arn"
+  input_name          = "TF_VAR_runners_controlled_role_arn"
+  trigger_always      = true
+}
+
+resource "spacelift_stack_dependency_reference" "crypto_github_webhook_lambda_role_arn" {
+  stack_dependency_id = spacelift_stack_dependency.crypto__auth.id
+  output_name         = "TF_VAR_github_webhook_lambda_role_arn"
+  input_name          = "TF_VAR_github_webhook_lambda_role_arn"
+  trigger_always      = true
+}
+
+resource "spacelift_stack_dependency_reference" "crypto_ssm_agent_role_arn" {
+  stack_dependency_id = spacelift_stack_dependency.crypto__auth.id
+  output_name         = "TF_VAR_ssm_agent_role_arn"
+  input_name          = "TF_VAR_ssm_agent_role_arn"
+  trigger_always      = true
+}
+

--- a/terraform/stacks/auth/output.tf
+++ b/terraform/stacks/auth/output.tf
@@ -21,3 +21,21 @@ output "TF_VAR_github_webhook_lambda_role_arn" {
   description = "The ARN of the IAM role that the GitHub Webhook Lambda should assume."
   sensitive   = true
 }
+
+output "TF_VAR_runners_role_arn" {
+  value       = aws_iam_role.runners.arn
+  description = "The ARN of the IAM role that the GitHub Actions runners should assume."
+  sensitive   = true
+}
+
+output "TF_VAR_runners_controlled_role_arn" {
+  value       = aws_iam_role.runners_controlled.arn
+  description = "The ARN of the IAM role that the GitHub Actions runners should pass to temporary instances."
+  sensitive   = true
+}
+
+output "TF_VAR_ssm_agent_role_arn" {
+  value       = aws_iam_role.ssm_agent.arn
+  description = "The ARN of the IAM role for generic SSM agent access."
+  sensitive   = true
+}

--- a/terraform/stacks/crypto/runners.tf
+++ b/terraform/stacks/crypto/runners.tf
@@ -19,6 +19,66 @@ resource "aws_kms_key" "runners" {
         },
         Action   = "kms:*"
         Resource = "*"
+      },
+      {
+        Sid    = "AllowRunners"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.runners_role_arn
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowRunnerControlledInstances"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.runners_controlled_role_arn
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowRunners"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.runners_role_arn
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowGitHubWebhookLambda"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.github_webhook_lambda_role_arn
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/terraform/stacks/crypto/ssm.tf
+++ b/terraform/stacks/crypto/ssm.tf
@@ -8,7 +8,7 @@ resource "aws_kms_key" "ssm_session_manager" {
     Id      = "key-1"
     Statement = [
       {
-        Sid    = "Enable IAM User Permissions"
+        Sid    = "EnableIAMUserPermissions"
         Effect = "Allow"
         Principal = {
           AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
@@ -17,7 +17,7 @@ resource "aws_kms_key" "ssm_session_manager" {
         Resource = "*"
       },
       {
-        Sid    = "Allow CloudWatch to use the key for SSM Session Manager logs"
+        Sid    = "AllowCloudWatchSSMSessionManagerlogs"
         Effect = "Allow"
         Principal = {
           Service = "logs.${data.aws_region.current.name}.amazonaws.com"
@@ -37,9 +37,10 @@ resource "aws_kms_key" "ssm_session_manager" {
         }
       },
       {
+        Sid    = "AllowRunners"
         Effect = "Allow"
         Principal = {
-          Service = "logs.${data.aws_region.current.name}.amazonaws.com"
+          AWS = var.runners_role_arn
         }
         Action = [
           "kms:Encrypt*",
@@ -49,11 +50,21 @@ resource "aws_kms_key" "ssm_session_manager" {
           "kms:Describe*"
         ]
         Resource = "*"
-        Condition = {
-          ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:ssm-session-manager"
-          }
+      },
+      {
+        Sid    = "AllowSSMAgents"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.ssm_agent_role_arn
         }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/terraform/stacks/crypto/variables.tf
+++ b/terraform/stacks/crypto/variables.tf
@@ -9,3 +9,27 @@ variable "control_owner" {
   type        = string
   description = "The owner of the GitHub repository for the control repository."
 }
+
+variable "runners_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role that the GitHub Actions runners should assume."
+  sensitive   = true
+}
+
+variable "runners_controlled_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role that the GitHub Actions runners should pass to temporary instances."
+  sensitive   = true
+}
+
+variable "github_webhook_lambda_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role that the GitHub Webhook Lambda should assume."
+  sensitive   = true
+}
+
+variable "ssm_agent_role_arn" {
+  type        = string
+  description = "The ARN of the IAM role for generic SSM agent access."
+  sensitive   = true
+}


### PR DESCRIPTION
This grants access to the KMS keys for SSM Session Manager and the
runners stack. The runners roles, webhooks roles, and the generic
SSM role all receive access to the KMS keys.

Refs: #362
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>