### PR TITLE
fix: allow runner-controlled instances SSM access

### DIFF
--- a/terraform/stacks/crypto/ssm.tf
+++ b/terraform/stacks/crypto/ssm.tf
@@ -65,6 +65,21 @@ resource "aws_kms_key" "ssm_session_manager" {
           "kms:Describe*"
         ]
         Resource = "*"
+      },
+      {
+        Sid    = "AllowRunnerControlledInstances"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.runners_controlled_role_arn
+        }
+        Action = [
+          "kms:Encrypt*",
+          "kms:Decrypt*",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:Describe*"
+        ]
+        Resource = "*"
       }
     ]
   })


### PR DESCRIPTION
This grants access to the KMS key used by SSM Session Manager to the
IAM roles used by instances controlled by the runners.

Refs: #362
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>