### PR TITLE
fix: runner-controlled SSM Session Manager Access

### DIFF
--- a/terraform/stacks/auth/runners.tf
+++ b/terraform/stacks/auth/runners.tf
@@ -117,6 +117,7 @@ resource "aws_iam_role" "runners_controlled" {
   assume_role_policy = data.aws_iam_policy_document.assume_role_ec2.json
 
   managed_policy_arns = [
+    aws_iam_policy.ssm_agent.arn,
     data.aws_iam_policy.AmazonSSMManagedInstanceCore.arn
   ]
 }


### PR DESCRIPTION
This grants access to runner-controlled instances via the SSM Session
Manager.

Refs: #362
Signed-off-by: Jaremy Hatler <hatler.jaremy@gmail.com>