### PR TITLE
fix: pre-16.10 ubuntu blocklist fixes

### DIFF
--- a/containers/ubuntu/_cloudimg/files/blocklist/init/common.txt
+++ b/containers/ubuntu/_cloudimg/files/blocklist/init/common.txt
@@ -1,17 +1,14 @@
-.*apparmor.*
-(lib|)cryptsetup.*
 (lib|)lxc.*
 (lib|)parted.*
 (lib|)python3[0-9t.]*(|-stdlib)
 accountsservice
+apparmor.*
 apport.*
 appstream
 apt-xapian-index
 at
 bcache-tools
-bind9-host
 btrfs-.*
-busybox.*
 byobu
 cgmanager
 cloud-.*
@@ -19,6 +16,7 @@ command-not-found.*
 console-setup.*
 consolekit
 cron.*
+cryptsetup.*
 dbus.*
 dconf.*
 dh-python

--- a/containers/ubuntu/_cloudimg/files/blocklist/init/legacy.txt
+++ b/containers/ubuntu/_cloudimg/files/blocklist/init/legacy.txt
@@ -9,6 +9,7 @@ dmeventd
 dmsetup
 init-system-helpers
 keyboard-configuration
+libcryptsetup.*
 libcurl3(|-gnutls)
 libdevmapper.*
 libgdbm3

--- a/containers/ubuntu/_cloudimg/files/blocklist/init/systemd_legacy.txt
+++ b/containers/ubuntu/_cloudimg/files/blocklist/init/systemd_legacy.txt
@@ -1,5 +1,6 @@
 acpid
 apt-transport-https
+busybox.*
 ca-certificates
 cpio
 curl

--- a/containers/ubuntu/_cloudimg/files/blocklist/init/systemd_modern.txt
+++ b/containers/ubuntu/_cloudimg/files/blocklist/init/systemd_modern.txt
@@ -4,6 +4,8 @@
 (lib|)systemd(|-sysv|-timesyncd|-hwe-hwdb|-networkd|-journald|-resolved|-services|-shared)
 acpid
 apt-transport-https
+bind9-host
+busybox.*
 ca-certificates
 cpio
 curl
@@ -20,9 +22,11 @@ initramfs.*
 iproute
 keyboard-configuration
 kmod
+libapparmor.*
 libarchive[0-9t]+
 libbind9.*
 libblockdev.*
+libcryptsetup.*
 libcurl3(|-gnutls)
 libdevmapper-.*
 libdns[0-9]+

--- a/containers/ubuntu/_cloudimg/files/blocklist/init/upstart.txt
+++ b/containers/ubuntu/_cloudimg/files/blocklist/init/upstart.txt
@@ -2,6 +2,7 @@
 (lib|)perl[0-9.]*(|-modules)
 acpid
 apt-transport-https
+busybox.*
 ca-certificates
 cpio
 curl
@@ -14,6 +15,7 @@ initramfs.*
 iproute
 keyboard-configuration
 kmod
+libcryptsetup.*
 libcurl3(|-gnutls)
 libdevmapper.*
 libgdbm3


### PR DESCRIPTION
The following fixes were applied to the blocklist files for pre-16.10 ubuntu cloud images:

- Don't remove libcryptsetup on legacy systemd containers.
- Only remove libapparmor.* on modern systemd containers.
- Only remove bind9-host on modern systemd containers.
- Only remove busyboxy on systems w/o initramfs

Fixes: https://github.com/jhatler/janus/issues/383
