### PR TITLE
feat: add Dockerfile sources for Ubuntu cloudimgs

### DIFF
--- a/containers/ubuntu/artful/Dockerfile
+++ b/containers/ubuntu/artful/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:artful-20180706
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:5754ebe6b4dfaaa1cfc55dd77d776ef4c3f961d182cfeb983c28c061b8132873"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/bionic-minimal/Dockerfile
+++ b/containers/ubuntu/bionic-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:bionic-minimal-20230602
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:b92f58d3a80962814045d1837e3b6600deab497d120c1f85c3b2408748524639"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/bionic/Dockerfile
+++ b/containers/ubuntu/bionic/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:bionic-20230607
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:3b3dee476fa449ec520d1787f9d8e092ec072faea248264e86b3cf87b7cc7fab"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/cosmic-minimal/Dockerfile
+++ b/containers/ubuntu/cosmic-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:cosmic-minimal-20190628
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:87f7a1f9c7171708a6ea45da41e3c232c1dbb33f50651ab32a9669082f2c774d"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/cosmic/Dockerfile
+++ b/containers/ubuntu/cosmic/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:cosmic-20190628
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:d0c4926c74999f5a732601c486b7e5b38f969fd57235dc01a1d9991bb9f46ae6"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/disco-minimal/Dockerfile
+++ b/containers/ubuntu/disco-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:disco-minimal-20200115
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:9ffe62f695e7b899ba49139134bd257a4cd7d95f86de7ab66fb95ce546c72a1f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/disco/Dockerfile
+++ b/containers/ubuntu/disco/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:disco-20200109
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:482f7e4db0ca654f371ae3a99f0dfa7ae429886696a09cb1e270abc9ce65988f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/eoan-minimal/Dockerfile
+++ b/containers/ubuntu/eoan-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:eoan-minimal-20200716
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:eaca8b11b2e0004d329b0826e3a081eece5059ebd926fa26618c772aaae4010f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/eoan/Dockerfile
+++ b/containers/ubuntu/eoan/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:eoan-20200717
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:9ef3f2b0638fbce04f9cee3b8e562ebc68c430d9ae2f8c4fb03cf589db4c5bf5"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/focal-minimal/Dockerfile
+++ b/containers/ubuntu/focal-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:focal-minimal-20240626
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:68471dcb02c2fee7a62b0bf833fc37f73a78b900a6fff1426bb6033717eb6112"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/focal/Dockerfile
+++ b/containers/ubuntu/focal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:focal-20240626
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:bd292c352d5cef1b56864ae11443da5800999a8a3edc54760d10fb0a880e22da"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/groovy-minimal/Dockerfile
+++ b/containers/ubuntu/groovy-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:groovy-minimal-20210720
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:55f005cba3d262310131aed8596b16b0422890bc061401ca21e446b056730bbe"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/groovy/Dockerfile
+++ b/containers/ubuntu/groovy/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:groovy-20210720
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:45c05ede691c1aa1e88eb91d822e183b32d12415565637e424afe9d7a9551f8f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/hardy/Dockerfile
+++ b/containers/ubuntu/hardy/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:hardy-20121003
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:8f2680edcfeef1782a0224828c10b86aae60da29eead6cf616f8c878698b76ea"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/hirsute-minimal/Dockerfile
+++ b/containers/ubuntu/hirsute-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:hirsute-minimal-20220119
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:88642520a90d03196cdd33ab3b1d4f6f898e7928bf2770e911146574c29733fb"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/hirsute/Dockerfile
+++ b/containers/ubuntu/hirsute/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:hirsute-20220118
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:abb8e9e09d211106b512912f52e5bb83f1aa053ddaedf5d7e7515878cd013c90"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/impish-minimal/Dockerfile
+++ b/containers/ubuntu/impish-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:impish-minimal-20220706
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:1fe8b1e148672b33976015f42f1d8f9c4177721bdb1bc4c01e6f29fb0f4c3cbb"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/impish/Dockerfile
+++ b/containers/ubuntu/impish/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:impish-20220708
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:6b89fc82269895776ee573183fce44ca4b7442e86c62f47ca53b9cc3ccaef6f7"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/jammy-minimal/Dockerfile
+++ b/containers/ubuntu/jammy-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:jammy-minimal-20240701
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:ae8cd0b3f66cd33c4a8c495bbd5af9a7e56123e3c6dd9628f31758dd2b56e445"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/jammy/Dockerfile
+++ b/containers/ubuntu/jammy/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:jammy-20240701
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:882fc2ec09126e5be049bb0091ff144ca91de53d0b4ab2d0365958c8de115b8f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/kinetic-minimal/Dockerfile
+++ b/containers/ubuntu/kinetic-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:kinetic-minimal-20230714
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:f9b7e8b19b676918342b2c3f9be26473954b794703f3b3da365468f660ee48a7"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/kinetic/Dockerfile
+++ b/containers/ubuntu/kinetic/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:kinetic-20230716
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:d72636642f586e4a2cf0b26ba307c14561f77ea5e7bd775d71d642351cdb9742"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/lucid/Dockerfile
+++ b/containers/ubuntu/lucid/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:lucid-20150427
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:689b22f812bcbb2622b164cde1961bdbb5899b815be64bc56a76ce0402ddcdf5"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/lunar-minimal/Dockerfile
+++ b/containers/ubuntu/lunar-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:lunar-minimal-20230420
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:e33261c0fcc5c37a0875b1e3db5e826e6161ac8e0b5169c893c130d23a2a7712"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/lunar/Dockerfile
+++ b/containers/ubuntu/lunar/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:lunar-20240115
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:4e3aac0521288a7d1ea995e08c4b1165664b594c01bdaa9c10ac3cab7f38bb40"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/mantic-minimal/Dockerfile
+++ b/containers/ubuntu/mantic-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:mantic-minimal-20240701.1
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:2163bd2c80764e1760b914717ddf487b66a41297a82e2d5546e9053585e8263c"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/mantic/Dockerfile
+++ b/containers/ubuntu/mantic/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:mantic-20240701
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:3e7876f7521b679882714e4521ceab3a9c576ed1d573df8b8a6c94c2a2d574b3"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/maverick/Dockerfile
+++ b/containers/ubuntu/maverick/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:maverick-20120410
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:efaa97954c2172c34ecaccd808531aa7bab67116d94ca155d4789c5128a3db6f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/natty/Dockerfile
+++ b/containers/ubuntu/natty/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:natty-20121028
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:4c7b886748f5ceae5146a5ff287af3d5eef41b1a06df1df0558f582bc5ded9ae"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/noble-minimal/Dockerfile
+++ b/containers/ubuntu/noble-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:noble-minimal-20240701.1
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:1a960ae40fe2c6b1100276e075a570a6689b825cd98354cea99921788f05292f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/noble/Dockerfile
+++ b/containers/ubuntu/noble/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:noble-20240702
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:6cc3721e5a07b8b24f71587096a83b56848d43831ba225442597620a370a9c51"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/oneiric/Dockerfile
+++ b/containers/ubuntu/oneiric/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:oneiric-20130509
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:a403b558d1d17d2265cb1c4e0c123b5ca2db898d224ebc1503f579bbda89482b"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/precise/Dockerfile
+++ b/containers/ubuntu/precise/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:precise-20170502
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:219a5ff64f11554dc85ad9c1fe26575ff18a4a8e0d8121cf00891d8f2af082aa"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/quantal/Dockerfile
+++ b/containers/ubuntu/quantal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:quantal-20140409
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:eff4bb34edd320be28a8af910dc7292906bbfb253b2a820955ad5df0bd0b00ac"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/raring/Dockerfile
+++ b/containers/ubuntu/raring/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:raring-20140111
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:dad26fe3acb8f041c6254bd35dc24a594e2fcd1843af4289241a002d0ae1dfad"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/saucy/Dockerfile
+++ b/containers/ubuntu/saucy/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:saucy-20140709
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:dc6734f3f01eb2b3fa7c0a7030f12ed68de7ae864cdc99361f58cba8019088a7"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/trusty/Dockerfile
+++ b/containers/ubuntu/trusty/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:trusty-20191107
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:25fef325fb1811bebe2821750c0cd83c130917294023436757a8d43d43a36fdc"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/utopic/Dockerfile
+++ b/containers/ubuntu/utopic/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:utopic-20150723
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:83e023e0905971cbbabf1f70b94b8867e72f6bc45fc9e36a4a62af95b73ecae0"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/vivid/Dockerfile
+++ b/containers/ubuntu/vivid/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:vivid-20160203
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:90ddf6dc52f1a4ef33964844007dbade60fc51f2e5cadbcfcfea949ecd987d97"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/wily/Dockerfile
+++ b/containers/ubuntu/wily/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:wily-20160715
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:9655b76f8e28c912aa194de2b062a31136cea0f37e14e7c5b788d44426386c29"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/xenial-minimal/Dockerfile
+++ b/containers/ubuntu/xenial-minimal/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:xenial-minimal-20210929
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:463c5692cc03613ecfc318140f1c5c77f6b69165c17927abefb5bba320b9f98b"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/xenial/Dockerfile
+++ b/containers/ubuntu/xenial/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:xenial-20211001
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:8348f92850031afdc84d376a4dddde58ff7e9fbd27146da0fd011381d639abd9"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/yakkety/Dockerfile
+++ b/containers/ubuntu/yakkety/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:yakkety-20170719
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:f4d6d9c2b0459382ccdf989f8ecf337b906882fe0c3c74b3a8931f0f3c2ff31b"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/ubuntu/zesty/Dockerfile
+++ b/containers/ubuntu/zesty/Dockerfile
@@ -1,0 +1,16 @@
+#checkov:skip=CKV_DOCKER_2:Not applicable
+#checkov:skip=CKV_DOCKER_3:Not applicable
+#checkov:skip=CKV_DOCKER_7:False positive
+
+# ghcr.io/jhatler/ubuntu-cloudimg:zesty-2017120
+ARG CONTAINER_REPO=ghcr.io/jhatler/ubuntu-cloudimg
+ARG CONTAINER_TAG="@sha256:bc41e8184ca909f5f31bf1ef12d7188d9a2847e6c20992e093442b135946ed6f"
+ARG CONTAINER_IMAGE="${CONTAINER_REPO}${CONTAINER_TAG}"
+
+# hadolint ignore=DL3006
+FROM ${CONTAINER_IMAGE}
+ARG TARGETARCH
+
+SHELL ["/bin/bash", "-o", "pipefail", "-ex", "-c"]
+ENV SHELL=/bin/bash
+ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This adds a Dockerfile for each Ubuntu cloudimg container that is supported by this project. This will allow for better change control when updating to newer cloudimg releases.

Fixes: #387