### PR TITLE
feat: bootstrap pyJanus testing

### DIFF
--- a/lib/pyjanus/.gitignore
+++ b/lib/pyjanus/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/lib/pyjanus/README.md
+++ b/lib/pyjanus/README.md
@@ -1,0 +1,1 @@
+# pyJanus

--- a/lib/pyjanus/__init__.py
+++ b/lib/pyjanus/__init__.py
@@ -1,5 +1,0 @@
-"""pyJanus"""
-
-
-def main():
-    """pyJanus main function."""

--- a/lib/pyjanus/setup.py
+++ b/lib/pyjanus/setup.py
@@ -23,9 +23,9 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
-    package_dir={"pyjanus": "lib/pyjanus"},
+    package_dir={"": "src"},
+    packages=setuptools.find_packages("src"),
     entry_points={"console_scripts": ["janus = pyjanus:main"]},
     install_requires=requirements,
-    packages=setuptools.find_packages(where="pyjanus"),
     python_requires=">=3.10",
 )

--- a/lib/pyjanus/src/pyjanus/__init__.py
+++ b/lib/pyjanus/src/pyjanus/__init__.py
@@ -1,0 +1,15 @@
+"""pyJanus"""
+
+
+def divide(a: int, b: int) -> float:
+    """Divide two numbers."""
+    return a / b
+
+
+def add(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
+
+
+def main():
+    """pyJanus main function."""

--- a/lib/pyjanus/src/pyjanus/tests/test__init__.py
+++ b/lib/pyjanus/src/pyjanus/tests/test__init__.py
@@ -1,0 +1,20 @@
+"""pyJanus __init__ tests"""
+
+import pyjanus
+import pytest  # pylint: disable=import-error
+
+
+def test_add():
+    """Test add function."""
+    assert pyjanus.add(1, 2) == 3
+
+
+def test_divide():
+    """Test add function."""
+    assert pyjanus.divide(132, 12) == 11
+
+
+def test_divide_zero():
+    """Test divide by zero."""
+    with pytest.raises(ZeroDivisionError):
+        pyjanus.divide(1, 0)


### PR DESCRIPTION
This commit adds the necessary files to bootstrap testing for the pyjanus library. The tests don't validate any of the library's code yet, but instead some basic arithmatic functions. The tests are written using the `pytest` framework.

Refs: #172