### PR TITLE
feat: authorize control repo for AWS

### DIFF
--- a/terraform/stacks/auth/main.tf
+++ b/terraform/stacks/auth/main.tf
@@ -1,14 +1,15 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-# module "github-oidc" {
-#   source  = "spacelift.io/jhatler/github-oidc/aws"
-#   version = "0.1.0"
+module "github-oidc" {
+  #checkov:skip=CKV_TF_1: Spacelift modules should be retrieved from Spacelift Module Registry
+  source  = "spacelift.io/jhatler/github-oidc/aws"
+  version = "0.2.2"
 
-#   # Required inputs
-#   github_owner      = var.control_owner
-#   github_repository = var.control_repository
-#   role_policies = [
-#     aws_iam_policy.gh_oidc_runners.arn
-#   ]
-# }
+  # Required inputs
+  github_owner      = var.control_owner
+  github_repository = var.control_repository
+  role_policies = [
+    aws_iam_policy.gh_oidc_runners.arn
+  ]
+}


### PR DESCRIPTION
This adds the github-oidc module to the `auth` stack to authorize the control repo for basic AWS access.

Fixes: #407