### PR TITLE
feat: ubuntu cloud images repository_dispatch

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,6 +2,11 @@
 name: "Ubuntu Cloud Images"
 
 on:
+  repository_dispatch:
+    types:
+      - ubuntu-cloud-images
+      - bootstrap
+
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This adds a repository_dispatch trigger to the Ubuntu Cloud Images workflow. This will allow the workflow to be triggered from the bootstrap workflow.

Fixes: #426