### PR TITLE
feat: parameterize packer network settings

### DIFF
--- a/packer/runners/ami.pkr.hcl
+++ b/packer/runners/ami.pkr.hcl
@@ -39,6 +39,21 @@ variable "runner_name" {
   type    = string
 }
 
+variable "vpc_name" {
+  type    = string
+  default = "Kernel"
+}
+
+variable "subnet_name" {
+  type    = string
+  default = "DMZ A"
+}
+
+variable "associate_public_ip_address" {
+  type    = bool
+  default = false
+}
+
 data "amazon-ami" "source" {
     filters = {
         virtualization-type = "hvm"
@@ -54,6 +69,8 @@ data "amazon-ami" "source" {
 source "amazon-ebs" "runner" {
   region =  "${var.aws_region}"
   instance_type =  "${var.instance_type}"
+
+  associate_public_ip_address = var.associate_public_ip_address
 
   ami_name =  "${var.ami_name} {{timestamp}}"
 
@@ -85,6 +102,20 @@ source "amazon-ebs" "runner" {
 
   tags = {
     "Name" = "${var.ami_name} {{timestamp}}"
+  }
+
+  vpc_filter {
+    filters = {
+      "tag:Name": var.vpc_name
+    }
+  }
+
+  subnet_filter {
+    filters = {
+      "tag:Name": var.subnet_name
+    }
+    most_free = true
+    random = false
   }
 }
 

--- a/packer/ubuntu-cloud-images/ami.pkr.hcl
+++ b/packer/ubuntu-cloud-images/ami.pkr.hcl
@@ -39,9 +39,26 @@ variable "ami_architecture" {
   type    = string
 }
 
+variable "vpc_name" {
+  type    = string
+  default = "Kernel"
+}
+
+variable "subnet_name" {
+  type    = string
+  default = "DMZ A"
+}
+
+variable "associate_public_ip_address" {
+  type    = bool
+  default = false
+}
+
 source "amazon-ebssurrogate" "ubuntu-cloud-images" {
   region =  "${var.aws_region}"
   instance_type =  "${var.instance_type}"
+
+  associate_public_ip_address = var.associate_public_ip_address
 
   force_deregister = true
   force_delete_snapshot = true
@@ -84,7 +101,6 @@ source "amazon-ebssurrogate" "ubuntu-cloud-images" {
     volume_type = "gp3"
   }
 
-
   run_tags = {
     "Name" = "Packer: ${var.ami_name}"
   }
@@ -99,6 +115,20 @@ source "amazon-ebssurrogate" "ubuntu-cloud-images" {
 
   tags = {
     "Name" = "${var.ami_name}"
+  }
+
+  vpc_filter {
+    filters = {
+      "tag:Name": var.vpc_name
+    }
+  }
+
+  subnet_filter {
+    filters = {
+      "tag:Name": var.subnet_name
+    }
+    most_free = true
+    random = false
   }
 }
 

--- a/packer/ubuntu-cloud-images/test.pkr.hcl
+++ b/packer/ubuntu-cloud-images/test.pkr.hcl
@@ -27,9 +27,26 @@ variable "cloud_config" {
   type    = string
 }
 
+variable "vpc_name" {
+  type    = string
+  default = "Kernel"
+}
+
+variable "subnet_name" {
+  type    = string
+  default = "DMZ A"
+}
+
+variable "associate_public_ip_address" {
+  type    = bool
+  default = false
+}
+
 source "amazon-ebs" "ubuntu-cloud-images-test" {
   region =  "${var.aws_region}"
   instance_type =  "${var.instance_type}"
+
+  associate_public_ip_address = var.associate_public_ip_address
 
   ssh_timeout = "5m"
 
@@ -56,6 +73,20 @@ source "amazon-ebs" "ubuntu-cloud-images-test" {
 
   run_volume_tags = {
     "Name" = "Packer Test: ${var.source_ami}"
+  }
+
+  vpc_filter {
+    filters = {
+      "tag:Name": var.vpc_name
+    }
+  }
+
+  subnet_filter {
+    filters = {
+      "tag:Name": var.subnet_name
+    }
+    most_free = true
+    random = false
   }
 }
 


### PR DESCRIPTION
This adds variables to each of the packer configurations to allow for the VPC, subnet, and public IP allocation settings to be passed in as variables. Each variables has a sane default for the project so that it remains backwards compatible with the current workflows.

Fixes: #434